### PR TITLE
Add command-line interface for BDInfo scanning and reporting

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -133,6 +133,7 @@
       <DependentUpon>FormSettings.cs</DependentUpon>
     </Compile>
     <Compile Include="ConsoleRunner.cs" />
+    <Compile Include="ConsoleWindow.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="FormChart.resx">

--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{3209AF1D-4762-4960-9DE5-13E90E77EE96}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BDInfo</RootNamespace>
     <AssemblyName>BDInfo</AssemblyName>

--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -132,6 +132,7 @@
     <Compile Include="FormSettings.Designer.cs">
       <DependentUpon>FormSettings.cs</DependentUpon>
     </Compile>
+    <Compile Include="ConsoleRunner.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="FormChart.resx">

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -40,50 +40,53 @@ namespace BDInfo
                 return false;
             }
 
-            CliOptions options;
-            try
+            using (ConsoleWindow.EnsureAttached())
             {
-                options = ParseArguments(args);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                PrintUsage();
-                Environment.ExitCode = 1;
+                CliOptions options;
+                try
+                {
+                    options = ParseArguments(args);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(ex.Message);
+                    PrintUsage();
+                    Environment.ExitCode = 1;
+                    return true;
+                }
+
+                if (options.ShowVersion)
+                {
+                    Console.WriteLine(GetVersionString());
+                    return true;
+                }
+
+                if (options.ShowHelp)
+                {
+                    PrintUsage();
+                    return true;
+                }
+
+                if (string.IsNullOrWhiteSpace(options.BdPath))
+                {
+                    Console.Error.WriteLine("BD_PATH is required.");
+                    PrintUsage();
+                    Environment.ExitCode = 1;
+                    return true;
+                }
+
+                try
+                {
+                    Run(options);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(ex.Message);
+                    Environment.ExitCode = 1;
+                }
+
                 return true;
             }
-
-            if (options.ShowVersion)
-            {
-                Console.WriteLine(GetVersionString());
-                return true;
-            }
-
-            if (options.ShowHelp)
-            {
-                PrintUsage();
-                return true;
-            }
-
-            if (string.IsNullOrWhiteSpace(options.BdPath))
-            {
-                Console.Error.WriteLine("BD_PATH is required.");
-                PrintUsage();
-                Environment.ExitCode = 1;
-                return true;
-            }
-
-            try
-            {
-                Run(options);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex.Message);
-                Environment.ExitCode = 1;
-            }
-
-            return true;
         }
 
         private static CliOptions ParseArguments(string[] args)

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -297,7 +297,7 @@ namespace BDInfo
 
             bool requiresReportDestination = !options.ListPlaylists || NeedsFurtherProcessing(options);
             string reportDestination = null;
-            string chartFormat = null;
+            ImageFormat chartFormat = null;
             string chartExtension = null;
 
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "BDInfo v{0}", GetVersionString()));
@@ -377,7 +377,7 @@ namespace BDInfo
 
                 if (options.SaveCharts)
                 {
-                    if (string.IsNullOrEmpty(chartFormat) || string.IsNullOrEmpty(chartExtension))
+                    if (chartFormat == null || string.IsNullOrEmpty(chartExtension))
                     {
                         (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
                     }

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -297,15 +297,17 @@ namespace BDInfo
             string reportDestination = options.ReportDestination;
             if (string.IsNullOrWhiteSpace(reportDestination))
             {
-                if (isFile)
+                string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                if (string.IsNullOrWhiteSpace(baseDirectory))
                 {
-                    throw new ArgumentException("REPORT_DEST is required when BD_PATH is an ISO file.");
+                    baseDirectory = Environment.CurrentDirectory;
                 }
-                reportDestination = bdPath;
+
+                reportDestination = baseDirectory;
             }
 
             reportDestination = Path.GetFullPath(reportDestination);
-            Directory.CreateDirectory(reportDestination);
+            EnsureReportDestination(reportDestination);
 
             var (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
 
@@ -366,6 +368,62 @@ namespace BDInfo
             finally
             {
                 bdrom?.CloseDiscImage();
+            }
+        }
+
+        private static void EnsureReportDestination(string destination)
+        {
+            if (string.IsNullOrWhiteSpace(destination))
+            {
+                throw new ArgumentException("Report destination cannot be empty.");
+            }
+
+            if (File.Exists(destination))
+            {
+                throw new IOException(string.Format(CultureInfo.InvariantCulture, "Report destination '{0}' is a file.", destination));
+            }
+
+            try
+            {
+                Directory.CreateDirectory(destination);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException(string.Format(CultureInfo.InvariantCulture, "Unable to create report destination '{0}': {1}", destination, ex.Message), ex);
+            }
+
+            string probeFile = Path.Combine(destination, Path.GetRandomFileName());
+            try
+            {
+                using (File.Create(probeFile, 1, FileOptions.DeleteOnClose))
+                {
+                }
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    using (File.Create(probeFile, 1))
+                    {
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException(string.Format(CultureInfo.InvariantCulture, "Unable to write to report destination '{0}': {1}", destination, ex.Message), ex);
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(probeFile))
+                    {
+                        File.Delete(probeFile);
+                    }
+                }
+                catch
+                {
+                }
             }
         }
 
@@ -519,6 +577,8 @@ namespace BDInfo
             }
 
             var playlistMap = new Dictionary<string, List<TSPlaylistFile>>(StringComparer.OrdinalIgnoreCase);
+            long totalBytes = 0;
+
             foreach (TSStreamFile streamFile in streamFiles)
             {
                 var mappedPlaylists = new List<TSPlaylistFile>();
@@ -536,27 +596,165 @@ namespace BDInfo
                         }
                     }
                 }
+
                 playlistMap[streamFile.Name] = mappedPlaylists;
+                totalBytes += GetStreamFileLength(streamFile);
             }
+
+            var progressBar = new CliProgressBar(totalBytes, streamFiles.Count);
+            long finishedBytes = 0;
+
+            progressBar.Report("Preparing scan", finishedBytes);
 
             foreach (TSStreamFile streamFile in streamFiles)
             {
+                string displayName = streamFile?.DisplayName ?? streamFile?.Name ?? string.Empty;
+                progressBar.Report(string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName), finishedBytes);
+
                 try
                 {
-                    if (!playlistMap.TryGetValue(streamFile.Name, out List<TSPlaylistFile> mappedPlaylists) || mappedPlaylists.Count == 0)
+                    if (playlistMap.TryGetValue(streamFile.Name, out List<TSPlaylistFile> mappedPlaylists) && mappedPlaylists.Count > 0)
                     {
-                        continue;
+                        streamFile.Scan(mappedPlaylists, true);
                     }
-
-                    streamFile.Scan(mappedPlaylists, true);
                 }
                 catch (Exception ex)
                 {
                     scanResult.FileExceptions[streamFile.Name] = ex;
                 }
+                finally
+                {
+                    finishedBytes += GetStreamFileLength(streamFile);
+                    progressBar.Report(string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName), finishedBytes);
+                }
             }
 
+            progressBar.Complete();
+
             return scanResult;
+        }
+
+        private static long GetStreamFileLength(TSStreamFile streamFile)
+        {
+            if (streamFile == null)
+            {
+                return 0;
+            }
+
+            if (BDInfoSettings.EnableSSIF && streamFile.InterleavedFile != null)
+            {
+                if (streamFile.InterleavedFile.FileInfo != null)
+                {
+                    return streamFile.InterleavedFile.FileInfo.Length;
+                }
+
+                if (streamFile.InterleavedFile.DFileInfo != null)
+                {
+                    return streamFile.InterleavedFile.DFileInfo.Length;
+                }
+            }
+
+            if (streamFile.FileInfo != null)
+            {
+                return streamFile.FileInfo.Length;
+            }
+
+            if (streamFile.DFileInfo != null)
+            {
+                return streamFile.DFileInfo.Length;
+            }
+
+            if (streamFile.Size > 0)
+            {
+                return streamFile.Size;
+            }
+
+            return 0;
+        }
+
+        private sealed class CliProgressBar
+        {
+            private readonly long _totalBytes;
+            private readonly int _barWidth;
+            private readonly bool _enabled;
+            private int _lastLength;
+
+            public CliProgressBar(long totalBytes, int itemCount, int barWidth = 40)
+            {
+                _enabled = itemCount > 0;
+                _barWidth = barWidth;
+                _totalBytes = totalBytes > 0 ? totalBytes : 1;
+
+                if (_enabled)
+                {
+                    Console.WriteLine();
+                }
+            }
+
+            public void Report(string message, long completedBytes)
+            {
+                if (!_enabled)
+                {
+                    return;
+                }
+
+                if (message == null)
+                {
+                    message = string.Empty;
+                }
+
+                long boundedBytes = completedBytes;
+                if (boundedBytes < 0)
+                {
+                    boundedBytes = 0;
+                }
+                if (boundedBytes > _totalBytes)
+                {
+                    boundedBytes = _totalBytes;
+                }
+
+                double progress = (double)boundedBytes / _totalBytes;
+                if (progress < 0)
+                {
+                    progress = 0;
+                }
+                if (progress > 1)
+                {
+                    progress = 1;
+                }
+
+                int filled = (int)Math.Round(progress * _barWidth);
+                if (filled < 0)
+                {
+                    filled = 0;
+                }
+                if (filled > _barWidth)
+                {
+                    filled = _barWidth;
+                }
+
+                if (message.Length > 60)
+                {
+                    message = message.Substring(0, 57) + "...";
+                }
+
+                string bar = new string('#', filled).PadRight(_barWidth);
+                string line = string.Format(CultureInfo.InvariantCulture, "[{0}] {1,3}% {2}", bar, (int)Math.Round(progress * 100), message);
+                int padding = Math.Max(0, _lastLength - line.Length);
+                Console.Write("\r{0}{1}", line, new string(' ', padding));
+                _lastLength = line.Length;
+            }
+
+            public void Complete()
+            {
+                if (!_enabled)
+                {
+                    return;
+                }
+
+                Report("Scan complete", _totalBytes);
+                Console.WriteLine();
+            }
         }
 
         private static string GenerateReport(BDROM bdrom, List<TSPlaylistFile> playlists, ScanBDROMResult scanResult, string destination)
@@ -647,7 +845,7 @@ namespace BDInfo
         {
             Console.WriteLine("Usage: BDInfo.exe <BD_PATH> [REPORT_DEST]");
             Console.WriteLine("BD_PATH may be a directory containing a BDMV folder or a BluRay ISO file.");
-            Console.WriteLine("REPORT_DEST is the folder the BDInfo report is to be written to. If not given, the report will be written to BD_PATH. REPORT_DEST is required if BD_PATH is an ISO file.");
+            Console.WriteLine("REPORT_DEST is the folder the BDInfo report is to be written to. If not given, the report will be written next to BDInfo.exe.");
             Console.WriteLine();
             Console.WriteLine("Options:");
             Console.WriteLine("  -?, --help, -h             Print out the options.");

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -349,6 +349,18 @@ namespace BDInfo
                     throw new InvalidOperationException("No playlists matched the supplied criteria.");
                 }
 
+                if (selectedPlaylists.Count > 0)
+                {
+                    Console.WriteLine("Playlists selected for scan:");
+                    foreach (TSPlaylistFile playlist in selectedPlaylists)
+                    {
+                        if (playlist != null)
+                        {
+                            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "  {0}", playlist.Name));
+                        }
+                    }
+                }
+
                 List<TSStreamFile> streamFiles = SelectStreamFiles(bdrom, selectedPlaylists, options.WholeDisc);
 
                 ScanBDROMResult scanResult = ScanStreamFiles(bdrom, selectedPlaylists, streamFiles);
@@ -779,12 +791,21 @@ namespace BDInfo
             foreach (TSStreamFile streamFile in streamFiles)
             {
                 string displayName = streamFile?.DisplayName ?? streamFile?.Name ?? string.Empty;
-                string message = string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName);
+                List<TSPlaylistFile> mappedPlaylists = null;
+                if (!playlistMap.TryGetValue(streamFile.Name, out mappedPlaylists) || mappedPlaylists == null)
+                {
+                    mappedPlaylists = new List<TSPlaylistFile>();
+                }
+
+                string playlistSummary = BuildPlaylistSummary(mappedPlaylists);
+                string message = string.IsNullOrEmpty(playlistSummary)
+                    ? string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName)
+                    : string.Format(CultureInfo.InvariantCulture, "Scanning {0} ({1})", displayName, playlistSummary);
                 progressBar.Report(message, finishedBytes);
 
                 try
                 {
-                    if (playlistMap.TryGetValue(streamFile.Name, out List<TSPlaylistFile> mappedPlaylists) && mappedPlaylists.Count > 0)
+                    if (mappedPlaylists.Count > 0)
                     {
                         Exception scanException = ScanStreamFileWithProgress(streamFile, mappedPlaylists, progressBar, message, finishedBytes);
                         if (scanException != null)
@@ -805,6 +826,29 @@ namespace BDInfo
             progressBar.Complete();
 
             return scanResult;
+        }
+
+        private static string BuildPlaylistSummary(IEnumerable<TSPlaylistFile> playlists)
+        {
+            if (playlists == null)
+            {
+                return string.Empty;
+            }
+
+            var names = playlists
+                .Where(p => p != null && !string.IsNullOrWhiteSpace(p.Name))
+                .Select(p => p.Name.Trim())
+                .Where(n => n.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (names.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(", ", names);
         }
 
         private static Exception ScanStreamFileWithProgress(

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1,0 +1,658 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace BDInfo
+{
+    internal static class ConsoleRunner
+    {
+        private static readonly string[] ChartTypes = new[]
+        {
+            "Video Bitrate: 1-Second Window",
+            "Video Bitrate: 5-Second Window",
+            "Video Bitrate: 10-Second Window",
+            "Video Frame Size (Min / Max)",
+            "Video Frame Type Counts",
+            "Video Frame Type Sizes"
+        };
+
+        private sealed class CliOptions
+        {
+            public string BdPath;
+            public string ReportDestination;
+            public bool ShowHelp;
+            public bool ShowVersion;
+            public bool ListPlaylists;
+            public bool WholeDisc;
+            public bool SaveCharts;
+            public string ChartFormat = "png";
+            public List<string> PlaylistNames { get; } = new List<string>();
+        }
+
+        public static bool TryHandle(string[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return false;
+            }
+
+            CliOptions options;
+            try
+            {
+                options = ParseArguments(args);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                PrintUsage();
+                Environment.ExitCode = 1;
+                return true;
+            }
+
+            if (options.ShowVersion)
+            {
+                Console.WriteLine(GetVersionString());
+                return true;
+            }
+
+            if (options.ShowHelp)
+            {
+                PrintUsage();
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(options.BdPath))
+            {
+                Console.Error.WriteLine("BD_PATH is required.");
+                PrintUsage();
+                Environment.ExitCode = 1;
+                return true;
+            }
+
+            try
+            {
+                Run(options);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                Environment.ExitCode = 1;
+            }
+
+            return true;
+        }
+
+        private static CliOptions ParseArguments(string[] args)
+        {
+            var options = new CliOptions();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string arg = args[i];
+                if (string.IsNullOrWhiteSpace(arg))
+                {
+                    continue;
+                }
+
+                if (IsHelpOption(arg))
+                {
+                    options.ShowHelp = true;
+                    continue;
+                }
+
+                if (IsVersionOption(arg))
+                {
+                    options.ShowVersion = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-l", "--list"))
+                {
+                    options.ListPlaylists = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-w", "--whole"))
+                {
+                    options.WholeDisc = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-m", "--mpls"))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-m", "--mpls");
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new ArgumentException("The --mpls option requires a comma separated list of playlists.");
+                    }
+                    options.PlaylistNames.AddRange(SplitValues(value));
+                    continue;
+                }
+
+                if (IsOption(arg, "-c", "--charts"))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-c", "--charts", allowMissingValue: true);
+                    options.SaveCharts = true;
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        options.ChartFormat = value;
+                    }
+                    continue;
+                }
+
+                if (arg.StartsWith("-", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unknown option: {0}", arg));
+                }
+
+                if (string.IsNullOrEmpty(options.BdPath))
+                {
+                    options.BdPath = arg;
+                }
+                else if (string.IsNullOrEmpty(options.ReportDestination))
+                {
+                    options.ReportDestination = arg;
+                }
+                else
+                {
+                    throw new ArgumentException("Too many positional arguments supplied.");
+                }
+            }
+
+            return options;
+        }
+
+        private static bool IsHelpOption(string value)
+        {
+            return string.Equals(value, "-?", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsVersionOption(string value)
+        {
+            return string.Equals(value, "-v", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsOption(string value, string shortOption, string longOption)
+        {
+            if (string.Equals(value, shortOption, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, longOption, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(longOption)
+                && value.StartsWith(longOption + "=", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(shortOption)
+                && value.StartsWith(shortOption + "=", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(shortOption)
+                && shortOption.Length == 2
+                && value.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase)
+                && value.Length > shortOption.Length
+                && value[shortOption.Length] != '=')
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string ExtractOptionValue(string[] args, ref int index, string shortOption, string longOption, bool allowMissingValue = false)
+        {
+            string arg = args[index];
+
+            if (!string.IsNullOrEmpty(longOption) && arg.StartsWith(longOption, StringComparison.OrdinalIgnoreCase))
+            {
+                if (arg.Length == longOption.Length)
+                {
+                    if (allowMissingValue)
+                    {
+                        return null;
+                    }
+
+                    if (index + 1 >= args.Length)
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", longOption));
+                    }
+
+                    index++;
+                    return args[index];
+                }
+
+                if (arg[longOption.Length] == '=')
+                {
+                    return arg.Substring(longOption.Length + 1);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(shortOption) && arg.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase))
+            {
+                if (arg.Length == shortOption.Length)
+                {
+                    if (allowMissingValue)
+                    {
+                        return null;
+                    }
+
+                    if (index + 1 >= args.Length)
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", shortOption));
+                    }
+
+                    index++;
+                    return args[index];
+                }
+
+                if (arg[shortOption.Length] == '=')
+                {
+                    return arg.Substring(shortOption.Length + 1);
+                }
+
+                return arg.Substring(shortOption.Length);
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<string> SplitValues(string value)
+        {
+            return value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(v => v.Trim())
+                        .Where(v => v.Length > 0);
+        }
+
+        private static void Run(CliOptions options)
+        {
+            string bdPath = Path.GetFullPath(options.BdPath);
+            bool isDirectory = Directory.Exists(bdPath);
+            bool isFile = File.Exists(bdPath);
+
+            if (!isDirectory && !isFile)
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "The specified path does not exist: {0}", bdPath));
+            }
+
+            if (isFile && !string.Equals(Path.GetExtension(bdPath), ".iso", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("BD_PATH must be a directory containing a BDMV folder or an ISO file.");
+            }
+
+            string reportDestination = options.ReportDestination;
+            if (string.IsNullOrWhiteSpace(reportDestination))
+            {
+                if (isFile)
+                {
+                    throw new ArgumentException("REPORT_DEST is required when BD_PATH is an ISO file.");
+                }
+                reportDestination = bdPath;
+            }
+
+            reportDestination = Path.GetFullPath(reportDestination);
+            Directory.CreateDirectory(reportDestination);
+
+            var (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "BDInfo v{0}", GetVersionString()));
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Source: {0}", bdPath));
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report destination: {0}", reportDestination));
+
+            BDROM bdrom = null;
+            try
+            {
+                bdrom = new BDROM(bdPath);
+                AttachErrorHandlers(bdrom);
+                bdrom.Scan();
+
+                if (options.ListPlaylists)
+                {
+                    PrintPlaylistList(bdrom);
+                    if (!NeedsFurtherProcessing(options))
+                    {
+                        return;
+                    }
+                }
+
+                List<TSPlaylistFile> selectedPlaylists = SelectPlaylists(bdrom, options);
+                if (selectedPlaylists.Count == 0)
+                {
+                    throw new InvalidOperationException("No playlists matched the supplied criteria.");
+                }
+
+                List<TSStreamFile> streamFiles = SelectStreamFiles(bdrom, selectedPlaylists, options.WholeDisc);
+
+                ScanBDROMResult scanResult = ScanStreamFiles(bdrom, selectedPlaylists, streamFiles);
+
+                if (scanResult.ScanException != null)
+                {
+                    throw scanResult.ScanException;
+                }
+
+                if (scanResult.FileExceptions.Count > 0)
+                {
+                    Console.Error.WriteLine("Scan completed with errors:");
+                    foreach (var kvp in scanResult.FileExceptions)
+                    {
+                        Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "  {0}: {1}", kvp.Key, kvp.Value.Message));
+                    }
+                }
+
+                string reportPath = GenerateReport(bdrom, selectedPlaylists, scanResult, reportDestination);
+                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report written to: {0}", reportPath));
+
+                if (options.SaveCharts)
+                {
+                    string chartsDirectory = Path.Combine(reportDestination, "charts");
+                    int chartsSaved = SaveCharts(selectedPlaylists, chartsDirectory, chartFormat, chartExtension);
+                    Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Charts saved to: {0} ({1} files)", chartsDirectory, chartsSaved));
+                }
+            }
+            finally
+            {
+                bdrom?.CloseDiscImage();
+            }
+        }
+
+        private static bool NeedsFurtherProcessing(CliOptions options)
+        {
+            return options.PlaylistNames.Count > 0 || options.WholeDisc || options.SaveCharts;
+        }
+
+        private static void AttachErrorHandlers(BDROM bdrom)
+        {
+            bdrom.StreamClipFileScanError += (clip, ex) =>
+            {
+                Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Error scanning stream clip {0}: {1}", clip?.Name, ex.Message));
+                return true;
+            };
+
+            bdrom.StreamFileScanError += (stream, ex) =>
+            {
+                Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Error scanning stream file {0}: {1}", stream?.Name, ex.Message));
+                return true;
+            };
+
+            bdrom.PlaylistFileScanError += (playlist, ex) =>
+            {
+                Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Error scanning playlist {0}: {1}", playlist?.Name, ex.Message));
+                return true;
+            };
+        }
+
+        private static void PrintPlaylistList(BDROM bdrom)
+        {
+            Console.WriteLine("Playlists:");
+            var playlists = bdrom.PlaylistFiles.Values
+                .Where(p => p != null && p.IsValid)
+                .ToList();
+
+            playlists.Sort(FormMain.ComparePlaylistFiles);
+
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                TimeSpan length = new TimeSpan((long)(playlist.TotalLength * 10000000));
+                string size = playlist.FileSize > 0
+                    ? ToolBox.FormatFileSize(playlist.FileSize)
+                    : "-";
+
+                Console.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "  {0,-12}  {1}  {2,12}  {3,6} clips",
+                    playlist.Name,
+                    string.Format(CultureInfo.InvariantCulture, "{0:D2}:{1:D2}:{2:D2}", length.Hours, length.Minutes, length.Seconds),
+                    size,
+                    playlist.StreamClips.Count));
+            }
+        }
+
+        private static List<TSPlaylistFile> SelectPlaylists(BDROM bdrom, CliOptions options)
+        {
+            var playlists = new List<TSPlaylistFile>();
+            var playlistMap = bdrom.PlaylistFiles;
+
+            if (options.WholeDisc)
+            {
+                playlists.AddRange(playlistMap.Values.Where(p => p.IsValid));
+            }
+            else if (options.PlaylistNames.Count > 0)
+            {
+                foreach (string name in options.PlaylistNames)
+                {
+                    string normalized = NormalizePlaylistName(name);
+                    if (playlistMap.TryGetValue(normalized, out TSPlaylistFile playlist))
+                    {
+                        if (playlist.IsValid)
+                        {
+                            if (!playlists.Contains(playlist))
+                            {
+                                playlists.Add(playlist);
+                            }
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} is filtered out by the current settings.", normalized));
+                        }
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} was not found on the disc.", normalized));
+                    }
+                }
+            }
+            else
+            {
+                playlists.AddRange(playlistMap.Values.Where(p => p.IsValid));
+                playlists.Sort(FormMain.ComparePlaylistFiles);
+                if (playlists.Count > 1)
+                {
+                    playlists = new List<TSPlaylistFile> { playlists[0] };
+                }
+            }
+
+            playlists.Sort(FormMain.ComparePlaylistFiles);
+            return playlists;
+        }
+
+        private static string NormalizePlaylistName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return string.Empty;
+            }
+
+            string trimmed = name.Trim();
+            if (!trimmed.EndsWith(".MPLS", StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed += ".MPLS";
+            }
+
+            return trimmed.ToUpperInvariant();
+        }
+
+        private static List<TSStreamFile> SelectStreamFiles(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists, bool wholeDisc)
+        {
+            if (wholeDisc)
+            {
+                return bdrom.StreamFiles.Values.Where(s => s != null).Distinct().ToList();
+            }
+
+            var streamFiles = new List<TSStreamFile>();
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                foreach (TSStreamClip clip in playlist.StreamClips)
+                {
+                    if (clip.StreamFile != null && !streamFiles.Contains(clip.StreamFile))
+                    {
+                        streamFiles.Add(clip.StreamFile);
+                    }
+                }
+            }
+            return streamFiles;
+        }
+
+        private static ScanBDROMResult ScanStreamFiles(BDROM bdrom, List<TSPlaylistFile> playlists, List<TSStreamFile> streamFiles)
+        {
+            var scanResult = new ScanBDROMResult
+            {
+                ScanException = null
+            };
+
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                playlist.ClearBitrates();
+            }
+
+            var playlistMap = new Dictionary<string, List<TSPlaylistFile>>(StringComparer.OrdinalIgnoreCase);
+            foreach (TSStreamFile streamFile in streamFiles)
+            {
+                var mappedPlaylists = new List<TSPlaylistFile>();
+                foreach (TSPlaylistFile playlist in playlists)
+                {
+                    foreach (TSStreamClip clip in playlist.StreamClips)
+                    {
+                        if (clip.Name == streamFile.Name)
+                        {
+                            if (!mappedPlaylists.Contains(playlist))
+                            {
+                                mappedPlaylists.Add(playlist);
+                            }
+                            break;
+                        }
+                    }
+                }
+                playlistMap[streamFile.Name] = mappedPlaylists;
+            }
+
+            foreach (TSStreamFile streamFile in streamFiles)
+            {
+                try
+                {
+                    if (!playlistMap.TryGetValue(streamFile.Name, out List<TSPlaylistFile> mappedPlaylists) || mappedPlaylists.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    streamFile.Scan(mappedPlaylists, true);
+                }
+                catch (Exception ex)
+                {
+                    scanResult.FileExceptions[streamFile.Name] = ex;
+                }
+            }
+
+            return scanResult;
+        }
+
+        private static string GenerateReport(BDROM bdrom, List<TSPlaylistFile> playlists, ScanBDROMResult scanResult, string destination)
+        {
+            using (var report = new FormReport())
+            {
+                report.Generate(bdrom, playlists, scanResult);
+                string reportText = report.ReportText;
+
+                string volumeLabel = string.IsNullOrWhiteSpace(bdrom.VolumeLabel)
+                    ? "UNKNOWN"
+                    : bdrom.VolumeLabel;
+
+                string fileName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", volumeLabel));
+                string reportPath = Path.Combine(destination, fileName);
+                File.WriteAllText(reportPath, reportText);
+                return reportPath;
+            }
+        }
+
+        private static int SaveCharts(IEnumerable<TSPlaylistFile> playlists, string directory, ImageFormat format, string extension)
+        {
+            Directory.CreateDirectory(directory);
+            int savedCount = 0;
+
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                foreach (TSVideoStream videoStream in playlist.VideoStreams)
+                {
+                    for (int angleIndex = 0; angleIndex <= playlist.AngleStreams.Count; angleIndex++)
+                    {
+                        foreach (string chartType in ChartTypes)
+                        {
+                            try
+                            {
+                                using (var chart = new FormChart())
+                                {
+                                    chart.CreateControl();
+                                    chart.Generate(chartType, playlist, videoStream.PID, angleIndex);
+                                    chart.SaveChartImage(directory, format, extension);
+                                    savedCount++;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Failed to save chart for {0} ({1}): {2}", playlist.Name, chartType, ex.Message));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return savedCount;
+        }
+
+        private static (ImageFormat format, string extension) GetImageFormat(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return (ImageFormat.Png, ".png");
+            }
+
+            switch (name.Trim().ToLowerInvariant())
+            {
+                case "png":
+                    return (ImageFormat.Png, ".png");
+                case "jpg":
+                case "jpeg":
+                    return (ImageFormat.Jpeg, ".jpg");
+                case "bmp":
+                    return (ImageFormat.Bmp, ".bmp");
+                case "gif":
+                    return (ImageFormat.Gif, ".gif");
+                case "tif":
+                case "tiff":
+                    return (ImageFormat.Tiff, ".tiff");
+                default:
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported chart image format: {0}", name));
+            }
+        }
+
+        private static string GetVersionString()
+        {
+            return Application.ProductVersion;
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Usage: BDInfo.exe <BD_PATH> [REPORT_DEST]");
+            Console.WriteLine("BD_PATH may be a directory containing a BDMV folder or a BluRay ISO file.");
+            Console.WriteLine("REPORT_DEST is the folder the BDInfo report is to be written to. If not given, the report will be written to BD_PATH. REPORT_DEST is required if BD_PATH is an ISO file.");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            Console.WriteLine("  -?, --help, -h             Print out the options.");
+            Console.WriteLine("  -l, --list                 Print the list of playlists.");
+            Console.WriteLine("  -m, --mpls=VALUE           Comma separated list of playlists to scan.");
+            Console.WriteLine("  -w, --whole                Scan whole disc - every playlist.");
+            Console.WriteLine("  -v, --version              Print the version.");
+            Console.WriteLine("  -c, --charts               Save all charts as image (select image format, default png)");
+        }
+    }
+}

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -512,36 +512,30 @@ namespace BDInfo
             }
             else if (options.PlaylistNames.Count > 0)
             {
+                var seenPlaylists = new HashSet<TSPlaylistFile>();
                 foreach (string name in options.PlaylistNames)
                 {
-                    string normalized = NormalizePlaylistName(name);
-                    if (string.IsNullOrEmpty(normalized))
-                    {
-                        continue;
-                    }
-
-                    if (!playlistMap.TryGetValue(normalized, out TSPlaylistFile playlist))
-                    {
-                        playlist = playlistMap.Values.FirstOrDefault(p => string.Equals(p?.Name, normalized, StringComparison.OrdinalIgnoreCase));
-                    }
+                    IReadOnlyList<string> candidates = GetPlaylistNameCandidates(name);
+                    TSPlaylistFile playlist = ResolvePlaylistByCandidates(playlistMap, candidates);
+                    string displayName = GetPlaylistDisplayName(candidates, name);
 
                     if (playlist != null)
                     {
                         if (playlist.IsValid)
                         {
-                            if (!playlists.Contains(playlist))
+                            if (seenPlaylists.Add(playlist))
                             {
                                 playlists.Add(playlist);
                             }
                         }
                         else
                         {
-                            Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} is filtered out by the current settings.", normalized));
+                            Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} is filtered out by the current settings.", displayName));
                         }
                     }
-                    else
+                    else if (!string.IsNullOrEmpty(displayName))
                     {
-                        Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} was not found on the disc.", normalized));
+                        Console.Error.WriteLine(string.Format(CultureInfo.InvariantCulture, "Playlist {0} was not found on the disc.", displayName));
                     }
                 }
             }
@@ -587,6 +581,136 @@ namespace BDInfo
             baseName = baseName.ToUpperInvariant();
 
             return string.Format(CultureInfo.InvariantCulture, "{0}.MPLS", baseName);
+        }
+
+        private static IReadOnlyList<string> GetPlaylistNameCandidates(string name)
+        {
+            var results = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return results;
+            }
+
+            string trimmed = name.Trim();
+
+            void AddCandidate(string candidate)
+            {
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    return;
+                }
+
+                string trimmedCandidate = candidate.Trim();
+                if (trimmedCandidate.Length == 0)
+                {
+                    return;
+                }
+
+                string normalizedCandidate = trimmedCandidate.ToUpperInvariant();
+                if (seen.Add(normalizedCandidate))
+                {
+                    results.Add(normalizedCandidate);
+                }
+            }
+
+            AddCandidate(trimmed);
+
+            string fileName = Path.GetFileName(trimmed);
+            AddCandidate(fileName);
+
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            AddCandidate(baseName);
+
+            if (!string.IsNullOrEmpty(baseName))
+            {
+                AddCandidate(baseName + ".MPLS");
+
+                if (baseName.All(char.IsDigit))
+                {
+                    string padded = baseName.PadLeft(5, '0');
+                    AddCandidate(padded);
+                    AddCandidate(padded + ".MPLS");
+
+                    string unpadded = baseName.TrimStart('0');
+                    if (unpadded.Length == 0 && baseName.Length > 0)
+                    {
+                        unpadded = "0";
+                    }
+
+                    AddCandidate(unpadded);
+                    AddCandidate(unpadded + ".MPLS");
+                }
+            }
+
+            string normalized = NormalizePlaylistName(trimmed);
+            AddCandidate(normalized);
+
+            return results;
+        }
+
+        private static TSPlaylistFile ResolvePlaylistByCandidates(Dictionary<string, TSPlaylistFile> playlistMap, IReadOnlyList<string> candidates)
+        {
+            if (playlistMap == null || playlistMap.Count == 0 || candidates == null || candidates.Count == 0)
+            {
+                return null;
+            }
+
+            foreach (string candidate in candidates)
+            {
+                if (playlistMap.TryGetValue(candidate, out TSPlaylistFile playlist) && playlist != null)
+                {
+                    return playlist;
+                }
+            }
+
+            foreach (TSPlaylistFile playlist in playlistMap.Values)
+            {
+                if (playlist == null)
+                {
+                    continue;
+                }
+
+                string playlistName = playlist.Name ?? string.Empty;
+                string playlistBase = Path.GetFileNameWithoutExtension(playlistName) ?? string.Empty;
+
+                foreach (string candidate in candidates)
+                {
+                    if (string.Equals(playlistName, candidate, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return playlist;
+                    }
+
+                    if (!string.IsNullOrEmpty(playlistBase) && string.Equals(playlistBase, candidate, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return playlist;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetPlaylistDisplayName(IReadOnlyList<string> candidates, string originalName)
+        {
+            if (candidates != null && candidates.Count > 0)
+            {
+                return candidates[0];
+            }
+
+            string normalized = NormalizePlaylistName(originalName);
+            if (!string.IsNullOrEmpty(normalized))
+            {
+                return normalized;
+            }
+
+            if (!string.IsNullOrWhiteSpace(originalName))
+            {
+                return originalName.Trim();
+            }
+
+            return string.Empty;
         }
 
         private static List<TSStreamFile> SelectStreamFiles(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists, bool wholeDisc)

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -295,26 +295,37 @@ namespace BDInfo
                 throw new ArgumentException("BD_PATH must be a directory containing a BDMV folder or an ISO file.");
             }
 
-            string reportDestination = options.ReportDestination;
-            if (string.IsNullOrWhiteSpace(reportDestination))
-            {
-                string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                if (string.IsNullOrWhiteSpace(baseDirectory))
-                {
-                    baseDirectory = Environment.CurrentDirectory;
-                }
-
-                reportDestination = baseDirectory;
-            }
-
-            reportDestination = Path.GetFullPath(reportDestination);
-            EnsureReportDestination(reportDestination);
-
-            var (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+            bool requiresReportDestination = !options.ListPlaylists || NeedsFurtherProcessing(options);
+            string reportDestination = null;
+            string chartFormat = null;
+            string chartExtension = null;
 
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "BDInfo v{0}", GetVersionString()));
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Source: {0}", bdPath));
-            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report destination: {0}", reportDestination));
+
+            if (requiresReportDestination)
+            {
+                reportDestination = options.ReportDestination;
+                if (string.IsNullOrWhiteSpace(reportDestination))
+                {
+                    string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                    if (string.IsNullOrWhiteSpace(baseDirectory))
+                    {
+                        baseDirectory = Environment.CurrentDirectory;
+                    }
+
+                    reportDestination = baseDirectory;
+                }
+
+                reportDestination = Path.GetFullPath(reportDestination);
+                EnsureReportDestination(reportDestination);
+                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report destination: {0}", reportDestination));
+
+                if (options.SaveCharts)
+                {
+                    (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+                }
+            }
 
             BDROM bdrom = null;
             try
@@ -356,11 +367,21 @@ namespace BDInfo
                     }
                 }
 
+                if (reportDestination == null)
+                {
+                    throw new InvalidOperationException("Report destination was not resolved.");
+                }
+
                 string reportPath = GenerateReport(bdrom, selectedPlaylists, scanResult, reportDestination);
                 Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report written to: {0}", reportPath));
 
                 if (options.SaveCharts)
                 {
+                    if (string.IsNullOrEmpty(chartFormat) || string.IsNullOrEmpty(chartExtension))
+                    {
+                        (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+                    }
+
                     string chartsDirectory = Path.Combine(reportDestination, "charts");
                     int chartsSaved = SaveCharts(selectedPlaylists, chartsDirectory, chartFormat, chartExtension);
                     Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Charts saved to: {0} ({1} files)", chartsDirectory, chartsSaved));
@@ -494,7 +515,17 @@ namespace BDInfo
                 foreach (string name in options.PlaylistNames)
                 {
                     string normalized = NormalizePlaylistName(name);
-                    if (playlistMap.TryGetValue(normalized, out TSPlaylistFile playlist))
+                    if (string.IsNullOrEmpty(normalized))
+                    {
+                        continue;
+                    }
+
+                    if (!playlistMap.TryGetValue(normalized, out TSPlaylistFile playlist))
+                    {
+                        playlist = playlistMap.Values.FirstOrDefault(p => string.Equals(p?.Name, normalized, StringComparison.OrdinalIgnoreCase));
+                    }
+
+                    if (playlist != null)
                     {
                         if (playlist.IsValid)
                         {
@@ -536,12 +567,26 @@ namespace BDInfo
             }
 
             string trimmed = name.Trim();
-            if (!trimmed.EndsWith(".MPLS", StringComparison.OrdinalIgnoreCase))
+            string fileName = Path.GetFileName(trimmed);
+            if (string.IsNullOrEmpty(fileName))
             {
-                trimmed += ".MPLS";
+                fileName = trimmed;
             }
 
-            return trimmed.ToUpperInvariant();
+            string baseName = Path.GetFileNameWithoutExtension(fileName);
+            if (string.IsNullOrEmpty(baseName))
+            {
+                baseName = fileName;
+            }
+
+            if (baseName.All(char.IsDigit))
+            {
+                baseName = baseName.PadLeft(5, '0');
+            }
+
+            baseName = baseName.ToUpperInvariant();
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}.MPLS", baseName);
         }
 
         private static List<TSStreamFile> SelectStreamFiles(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists, bool wholeDisc)

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -4,6 +4,7 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace BDInfo
@@ -609,29 +610,83 @@ namespace BDInfo
             foreach (TSStreamFile streamFile in streamFiles)
             {
                 string displayName = streamFile?.DisplayName ?? streamFile?.Name ?? string.Empty;
-                progressBar.Report(string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName), finishedBytes);
+                string message = string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName);
+                progressBar.Report(message, finishedBytes);
 
                 try
                 {
                     if (playlistMap.TryGetValue(streamFile.Name, out List<TSPlaylistFile> mappedPlaylists) && mappedPlaylists.Count > 0)
                     {
-                        streamFile.Scan(mappedPlaylists, true);
+                        Exception scanException = ScanStreamFileWithProgress(streamFile, mappedPlaylists, progressBar, message, finishedBytes);
+                        if (scanException != null)
+                        {
+                            scanResult.FileExceptions[streamFile.Name] = scanException;
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
                     scanResult.FileExceptions[streamFile.Name] = ex;
                 }
-                finally
-                {
-                    finishedBytes += GetStreamFileLength(streamFile);
-                    progressBar.Report(string.Format(CultureInfo.InvariantCulture, "Scanning {0}", displayName), finishedBytes);
-                }
+
+                finishedBytes += GetStreamFileLength(streamFile);
+                progressBar.Report(message, finishedBytes);
             }
 
             progressBar.Complete();
 
             return scanResult;
+        }
+
+        private static Exception ScanStreamFileWithProgress(
+            TSStreamFile streamFile,
+            List<TSPlaylistFile> playlists,
+            CliProgressBar progressBar,
+            string message,
+            long completedBytes)
+        {
+            if (streamFile == null)
+            {
+                return null;
+            }
+
+            Exception scanException = null;
+
+            using (var scanCompleted = new ManualResetEventSlim(false))
+            {
+                Thread scanThread = new Thread(() =>
+                {
+                    try
+                    {
+                        streamFile.Scan(playlists, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        scanException = ex;
+                    }
+                    finally
+                    {
+                        scanCompleted.Set();
+                    }
+                })
+                {
+                    IsBackground = true
+                };
+
+                scanThread.Start();
+
+                const int pollIntervalMilliseconds = 200;
+                while (!scanCompleted.Wait(pollIntervalMilliseconds))
+                {
+                    progressBar.Report(message, completedBytes + streamFile.Size);
+                }
+
+                scanThread.Join();
+            }
+
+            progressBar.Report(message, completedBytes + streamFile.Size);
+
+            return scanException;
         }
 
         private static long GetStreamFileLength(TSStreamFile streamFile)

--- a/BDInfo/ConsoleWindow.cs
+++ b/BDInfo/ConsoleWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace BDInfo
@@ -28,11 +29,13 @@ namespace BDInfo
 
             if (AttachConsole(ATTACH_PARENT_PROCESS))
             {
+                ReinitializeConsoleStreams();
                 return new ConsoleScope(detachOnDispose: false);
             }
 
             if (AllocConsole())
             {
+                ReinitializeConsoleStreams();
                 return new ConsoleScope(detachOnDispose: true);
             }
 
@@ -42,6 +45,45 @@ namespace BDInfo
         private static bool HasConsole()
         {
             return GetConsoleWindow() != IntPtr.Zero;
+        }
+
+        private static void ReinitializeConsoleStreams()
+        {
+            try
+            {
+                Stream outputStream = Console.OpenStandardOutput();
+                var outputWriter = new StreamWriter(outputStream, Console.OutputEncoding)
+                {
+                    AutoFlush = true
+                };
+                Console.SetOut(outputWriter);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                Stream errorStream = Console.OpenStandardError();
+                var errorWriter = new StreamWriter(errorStream, Console.OutputEncoding)
+                {
+                    AutoFlush = true
+                };
+                Console.SetError(errorWriter);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                Stream inputStream = Console.OpenStandardInput();
+                var inputReader = new StreamReader(inputStream, Console.InputEncoding);
+                Console.SetIn(inputReader);
+            }
+            catch
+            {
+            }
         }
 
         private sealed class ConsoleScope : IDisposable

--- a/BDInfo/ConsoleWindow.cs
+++ b/BDInfo/ConsoleWindow.cs
@@ -17,6 +17,9 @@ namespace BDInfo
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool FreeConsole();
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern uint GetConsoleProcessList(uint[] processList, uint count);
+
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetConsoleWindow();
 
@@ -45,6 +48,22 @@ namespace BDInfo
         private static bool HasConsole()
         {
             return GetConsoleWindow() != IntPtr.Zero;
+        }
+
+        public static void ReleaseConsoleIfOwned()
+        {
+            IntPtr consoleWindow = GetConsoleWindow();
+            if (consoleWindow == IntPtr.Zero)
+            {
+                return;
+            }
+
+            uint[] processIds = new uint[1];
+            uint attachedProcessCount = GetConsoleProcessList(processIds, (uint)processIds.Length);
+            if (attachedProcessCount == 1)
+            {
+                FreeConsole();
+            }
         }
 
         private static void ReinitializeConsoleStreams()

--- a/BDInfo/ConsoleWindow.cs
+++ b/BDInfo/ConsoleWindow.cs
@@ -26,12 +26,17 @@ namespace BDInfo
                 return NoOp.Instance;
             }
 
-            if (!AttachConsole(ATTACH_PARENT_PROCESS) && !AllocConsole())
+            if (AttachConsole(ATTACH_PARENT_PROCESS))
             {
-                return NoOp.Instance;
+                return new ConsoleScope(detachOnDispose: false);
             }
 
-            return new ConsoleScope();
+            if (AllocConsole())
+            {
+                return new ConsoleScope(detachOnDispose: true);
+            }
+
+            return NoOp.Instance;
         }
 
         private static bool HasConsole()
@@ -42,6 +47,12 @@ namespace BDInfo
         private sealed class ConsoleScope : IDisposable
         {
             private bool _disposed;
+            private readonly bool _detachOnDispose;
+
+            public ConsoleScope(bool detachOnDispose)
+            {
+                _detachOnDispose = detachOnDispose;
+            }
 
             public void Dispose()
             {
@@ -67,7 +78,10 @@ namespace BDInfo
                 {
                 }
 
-                FreeConsole();
+                if (_detachOnDispose)
+                {
+                    FreeConsole();
+                }
             }
         }
 

--- a/BDInfo/ConsoleWindow.cs
+++ b/BDInfo/ConsoleWindow.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace BDInfo
+{
+    internal static class ConsoleWindow
+    {
+        private const uint ATTACH_PARENT_PROCESS = 0xFFFFFFFF;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AttachConsole(uint dwProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AllocConsole();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool FreeConsole();
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetConsoleWindow();
+
+        public static IDisposable EnsureAttached()
+        {
+            if (HasConsole())
+            {
+                return NoOp.Instance;
+            }
+
+            if (!AttachConsole(ATTACH_PARENT_PROCESS) && !AllocConsole())
+            {
+                return NoOp.Instance;
+            }
+
+            return new ConsoleScope();
+        }
+
+        private static bool HasConsole()
+        {
+            return GetConsoleWindow() != IntPtr.Zero;
+        }
+
+        private sealed class ConsoleScope : IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                try
+                {
+                    Console.Out.Flush();
+                }
+                catch
+                {
+                }
+
+                try
+                {
+                    Console.Error.Flush();
+                }
+                catch
+                {
+                }
+
+                FreeConsole();
+            }
+        }
+
+        private sealed class NoOp : IDisposable
+        {
+            public static readonly NoOp Instance = new NoOp();
+
+            private NoOp()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/BDInfo/FormChart.cs
+++ b/BDInfo/FormChart.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
@@ -146,6 +147,41 @@ namespace BDInfo
                     break;
             }
             DefaultFileName += ".png";
+        }
+
+        public string SaveChartImage(
+            string directory,
+            ImageFormat format,
+            string extension)
+        {
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                throw new ArgumentException("directory");
+            }
+
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".png";
+            }
+
+            Directory.CreateDirectory(directory);
+
+            string baseName = Path.GetFileNameWithoutExtension(DefaultFileName);
+            string safeName = ToolBox.GetSafeFileName(baseName);
+            string fileName = safeName + extension;
+            string fullPath = Path.Combine(directory, fileName);
+
+            using (Image image = GraphControl.GetImage())
+            {
+                image.Save(fullPath, format);
+            }
+
+            return fullPath;
         }
 
         private string FixVolumeLabel(string label)

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -29,6 +29,11 @@ namespace BDInfo
     {
         private List<TSPlaylistFile> Playlists;
 
+        public string ReportText
+        {
+            get { return textBoxReport.Text; }
+        }
+
         public FormReport()
         {
             InitializeComponent();

--- a/BDInfo/Program.cs
+++ b/BDInfo/Program.cs
@@ -31,6 +31,11 @@ namespace BDInfo
         [STAThread]
         static void Main(string[] args)
         {
+            if (ConsoleRunner.TryHandle(args))
+            {
+                return;
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new FormMain(args));

--- a/BDInfo/Program.cs
+++ b/BDInfo/Program.cs
@@ -37,6 +37,8 @@ namespace BDInfo
                 return;
             }
 
+            ConsoleWindow.ReleaseConsoleIfOwned();
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new FormMain(args));

--- a/BDInfo/Program.cs
+++ b/BDInfo/Program.cs
@@ -33,6 +33,7 @@ namespace BDInfo
         {
             if (ConsoleRunner.TryHandle(args))
             {
+                Environment.Exit(Environment.ExitCode);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- add a ConsoleRunner that enables using BDInfo from the command line with playlist selection, whole-disc scans, report generation, and chart export
- expose the generated report text and chart-saving helpers so the CLI can reuse existing report/chart builders
- update the application entry point and project file to wire the CLI in before launching the WinForms UI

## Testing
- attempted to run `dotnet build BDInfo/BDInfo.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eccf5f74f0832495723bd9e798089e