### PR TITLE
Add UI to open previously saved reports

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -126,6 +126,7 @@
     <Compile Include="FormReport.Designer.cs">
       <DependentUpon>FormReport.cs</DependentUpon>
     </Compile>
+    <Compile Include="ReportPersistence.cs" />
     <Compile Include="FormSettings.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/BDInfo/FormChart.cs
+++ b/BDInfo/FormChart.cs
@@ -91,33 +91,7 @@ namespace BDInfo
             ushort PID,
             int angleIndex)
         {
-            this.Text = string.Format("{0}: {1}", playlist.Name, chartType);
-            GraphControl.GraphPane.Title.Text = chartType;
-            GraphControl.IsEnableHEdit = false;
-            GraphControl.IsEnableVEdit = false;
-            GraphControl.IsEnableVPan = false;
-            GraphControl.IsEnableVZoom = false;
-            GraphControl.IsShowHScrollBar = true;
-            GraphControl.IsAutoScrollRange = true;
-            GraphControl.IsEnableHPan = true;
-            GraphControl.IsEnableHZoom = true;
-            GraphControl.IsEnableSelection = true;
-            GraphControl.IsEnableWheelZoom = true;
-            GraphControl.GraphPane.Legend.IsVisible = false;
-            GraphControl.GraphPane.XAxis.Scale.IsUseTenPower = false;
-            GraphControl.GraphPane.YAxis.Scale.IsUseTenPower = false;
-
-            if (BDInfoSettings.UseImagePrefix)
-            {
-                DefaultFileName = BDInfoSettings.UseImagePrefixValue;
-            }
-            else
-            {
-                DefaultFileName = string.Format(
-                    "{0}-{1}-",
-                    FixVolumeLabel(playlist.BDROM.VolumeLabel),
-                    Path.GetFileNameWithoutExtension(playlist.Name));
-            }
+            PrepareGraph(chartType, playlist.BDROM?.VolumeLabel, playlist.Name);
 
             switch (chartType)
             {
@@ -147,6 +121,96 @@ namespace BDInfo
                     break;
             }
             DefaultFileName += ".png";
+        }
+
+        private void PrepareGraph(string chartType, string volumeLabel, string playlistName)
+        {
+            this.Text = string.Format("{0}: {1}", playlistName, chartType);
+            GraphControl.GraphPane.Title.Text = chartType;
+            GraphControl.IsEnableHEdit = false;
+            GraphControl.IsEnableVEdit = false;
+            GraphControl.IsEnableVPan = false;
+            GraphControl.IsEnableVZoom = false;
+            GraphControl.IsShowHScrollBar = true;
+            GraphControl.IsAutoScrollRange = true;
+            GraphControl.IsEnableHPan = true;
+            GraphControl.IsEnableHZoom = true;
+            GraphControl.IsEnableSelection = true;
+            GraphControl.IsEnableWheelZoom = true;
+            GraphControl.GraphPane.Legend.IsVisible = false;
+            GraphControl.GraphPane.XAxis.Scale.IsUseTenPower = false;
+            GraphControl.GraphPane.YAxis.Scale.IsUseTenPower = false;
+
+            if (BDInfoSettings.UseImagePrefix)
+            {
+                DefaultFileName = BDInfoSettings.UseImagePrefixValue;
+            }
+            else
+            {
+                string safeLabel = string.IsNullOrWhiteSpace(volumeLabel) ? "REPORT" : volumeLabel;
+                DefaultFileName = string.Format(
+                    "{0}-{1}-",
+                    FixVolumeLabel(safeLabel),
+                    Path.GetFileNameWithoutExtension(playlistName));
+            }
+        }
+
+        public void Generate(
+            string chartType,
+            SavedReportData report,
+            SavedPlaylistData playlist,
+            SavedVideoStreamData stream,
+            int angleIndex)
+        {
+            string volumeLabel = report?.VolumeLabel ?? string.Empty;
+            PrepareGraph(chartType, volumeLabel, playlist.Name);
+
+            switch (chartType)
+            {
+                case "Video Bitrate: 1-Second Window":
+                    GenerateWindowChart(playlist, stream, angleIndex, 1);
+                    DefaultFileName += "bitrate-01s";
+                    break;
+                case "Video Bitrate: 5-Second Window":
+                    GenerateWindowChart(playlist, stream, angleIndex, 5);
+                    DefaultFileName += "bitrate-05s";
+                    break;
+                case "Video Bitrate: 10-Second Window":
+                    GenerateWindowChart(playlist, stream, angleIndex, 10);
+                    DefaultFileName += "bitrate-10s";
+                    break;
+                case "Video Frame Size (Min / Max)":
+                    GenerateFrameSizeChart(playlist, stream, angleIndex);
+                    DefaultFileName += "frame-size";
+                    break;
+                case "Video Frame Type Counts":
+                    GenerateFrameTypeChart(playlist, stream, angleIndex, false);
+                    DefaultFileName += "frame-type-count";
+                    break;
+                case "Video Frame Type Sizes":
+                    GenerateFrameTypeChart(playlist, stream, angleIndex, true);
+                    DefaultFileName += "frame-type-size";
+                    break;
+            }
+
+            DefaultFileName += ".png";
+        }
+
+        private static List<SavedStreamDiagnosticsData> GetDiagnostics(
+            SavedStreamClipData clip,
+            ushort pid)
+        {
+            if (clip.Diagnostics == null)
+            {
+                return null;
+            }
+
+            if (clip.Diagnostics.ContainsKey(pid))
+            {
+                return clip.Diagnostics[pid];
+            }
+
+            return null;
         }
 
         public string SaveChartImage(
@@ -240,6 +304,148 @@ namespace BDInfo
                         diag.Marker -
                         clip.TimeIn +
                         clip.RelativeTimeIn;
+
+                    double seconds = diag.Interval;
+                    double bits = diag.Bytes * 8.0;
+
+                    windowSecondsSum += seconds;
+                    windowSeconds.Enqueue(seconds);
+                    windowBitsSum += bits;
+                    windowBits.Enqueue(bits);
+
+                    if (windowSecondsSum > windowSize)
+                    {
+                        double bitrate = windowBitsSum / windowSecondsSum / 1000000;
+
+                        if (bitrate < pointMin) pointMin = bitrate;
+                        if (bitrate > pointMax) pointMax = bitrate;
+                        pointCount++; pointAvg += bitrate;
+
+                        for (double x = pointSeconds; x < (pointPosition - 1); x++)
+                        {
+                            double pointX = (x - 1) / 60;
+                            pointsMin.Add(pointX, 0);
+                            pointsAvg.Add(pointX, 0);
+                            pointsMax.Add(pointX, 0);
+                            pointSeconds += 1;
+                        }
+
+                        if (pointPosition >= pointSeconds)
+                        {
+                            double pointMinutes = (pointSeconds - 1) / 60;
+                            pointsMin.Add(pointMinutes, pointMin);
+                            pointsMax.Add(pointMinutes, pointMax);
+                            pointsAvg.Add(pointMinutes, pointAvg / pointCount);
+                            pointMin = double.MaxValue;
+                            pointMax = 0;
+                            pointAvg = 0;
+                            pointCount = 0;
+                            pointSeconds += 1;
+                        }
+
+                        windowBitsSum -= windowBits.Dequeue();
+                        windowSecondsSum -= windowSeconds.Dequeue();
+                    }
+
+                    if (pointPosition >= pointSeconds)
+                    {
+                        for (double x = pointSeconds; x < (pointPosition - 1); x++)
+                        {
+                            double pointX = (x - 1) / 60;
+                            pointsMin.Add(pointX, 0);
+                            pointsAvg.Add(pointX, 0);
+                            pointsMax.Add(pointX, 0);
+                            pointSeconds += 1;
+                        }
+                        double pointMinutes = (pointSeconds - 1) / 60;
+                        pointsMin.Add(pointMinutes, pointMin);
+                        pointsAvg.Add(pointMinutes, pointAvg / pointCount);
+                        pointsMax.Add(pointMinutes, pointMax);
+                        pointMin = double.MaxValue;
+                        pointMax = 0;
+                        pointAvg = 0;
+                        pointCount = 0;
+                        pointSeconds += 1;
+                    }
+                }
+            }
+
+            for (double x = pointSeconds; x < playlist.TotalLength; x++)
+            {
+                double pointX = (x - 1) / 60;
+                pointsMin.Add(pointX, 0);
+                pointsAvg.Add(pointX, 0);
+                pointsMax.Add(pointX, 0);
+            }
+
+            LineItem avgCurve = GraphControl.GraphPane.AddCurve(
+                "Avg", pointsAvg, Color.Gray, SymbolType.None);
+            avgCurve.Line.IsSmooth = true;
+
+            LineItem minCurve = GraphControl.GraphPane.AddCurve(
+                "Min", pointsMin, Color.LightGray, SymbolType.None);
+            minCurve.Line.IsSmooth = true;
+            minCurve.Line.Fill = new Fill(Color.White);
+
+            LineItem maxCurve = GraphControl.GraphPane.AddCurve(
+                "Max", pointsMax, Color.LightGray, SymbolType.None);
+            maxCurve.Line.IsSmooth = true;
+            maxCurve.Line.Fill = new Fill(Color.LightGray);
+
+            GraphControl.GraphPane.XAxis.Scale.Min = 0;
+            GraphControl.GraphPane.XAxis.Scale.Max = playlist.TotalLength / 60;
+            GraphControl.GraphPane.YAxis.Scale.Min = 0;
+            GraphControl.GraphPane.Y2Axis.Scale.Min = 0;
+            GraphControl.GraphPane.Y2Axis.IsVisible = true;
+
+            GraphControl.AxisChange();
+        }
+
+        private void GenerateWindowChart(
+            SavedPlaylistData playlist,
+            SavedVideoStreamData stream,
+            int angleIndex,
+            double windowSize)
+        {
+            UnitText = "Mbps";
+
+            GraphControl.GraphPane.XAxis.Title.Text = "Time (minutes)";
+            GraphControl.GraphPane.YAxis.Title.Text = "Bitrate (Mbps)";
+
+            PointPairList pointsMin = new PointPairList();
+            PointPairList pointsMax = new PointPairList();
+            PointPairList pointsAvg = new PointPairList();
+
+            Queue<double> windowBits = new Queue<double>();
+            Queue<double> windowSeconds = new Queue<double>();
+            double windowBitsSum = 0;
+            double windowSecondsSum = 0;
+
+            double pointPosition = 0;
+            double pointSeconds = 1.0;
+            double pointMin = double.MaxValue;
+            double pointMax = 0;
+            double pointAvg = 0;
+            int pointCount = 0;
+
+            foreach (SavedStreamClipData clip in playlist.Clips)
+            {
+                if (clip.AngleIndex != angleIndex)
+                {
+                    continue;
+                }
+
+                List<SavedStreamDiagnosticsData> diagList = GetDiagnostics(clip, stream.PID);
+                if (diagList == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < diagList.Count; i++)
+                {
+                    SavedStreamDiagnosticsData diag = diagList[i];
+
+                    pointPosition = diag.Marker - clip.TimeIn + clip.RelativeTimeIn;
 
                     double seconds = diag.Interval;
                     double bits = diag.Bytes * 8.0;
@@ -446,6 +652,111 @@ namespace BDInfo
             GraphControl.AxisChange();
         }
 
+        private void GenerateFrameSizeChart(
+            SavedPlaylistData playlist,
+            SavedVideoStreamData stream,
+            int angleIndex)
+        {
+            UnitText = "KB";
+
+            GraphControl.GraphPane.XAxis.Title.Text = "Time (minutes)";
+            GraphControl.GraphPane.YAxis.Title.Text = "Size (KB)";
+
+            PointPairList pointsMin = new PointPairList();
+            PointPairList pointsMax = new PointPairList();
+            PointPairList pointsAvg = new PointPairList();
+
+            double pointPosition = 0;
+            double pointSeconds = 1.0;
+            double pointMin = double.MaxValue;
+            double pointMax = 0;
+            double pointAvg = 0;
+            int pointCount = 0;
+            double overallMax = 0;
+
+            foreach (SavedStreamClipData clip in playlist.Clips)
+            {
+                if (clip.AngleIndex != angleIndex)
+                {
+                    continue;
+                }
+
+                List<SavedStreamDiagnosticsData> diagList = GetDiagnostics(clip, stream.PID);
+                if (diagList == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < diagList.Count; i++)
+                {
+                    SavedStreamDiagnosticsData diag = diagList[i];
+                    if (diag.Tag == null) continue;
+
+                    double frameSize = diag.Bytes / 1024.0;
+
+                    pointPosition = diag.Marker - clip.TimeIn + clip.RelativeTimeIn;
+
+                    if (frameSize > overallMax) overallMax = frameSize;
+                    if (frameSize < pointMin) pointMin = frameSize;
+                    if (frameSize > pointMax) pointMax = frameSize;
+
+                    pointCount++;
+                    pointAvg += frameSize;
+
+                    if (pointPosition >= pointSeconds)
+                    {
+                        for (double x = pointSeconds; x < (pointPosition - 1); x++)
+                        {
+                            double pointX = (x - 1) / 60;
+                            pointsMin.Add(pointX, 0);
+                            pointsAvg.Add(pointX, 0);
+                            pointsMax.Add(pointX, 0);
+                            pointSeconds += 1;
+                        }
+                        double pointMinutes = (pointSeconds - 1) / 60;
+                        pointsMin.Add(pointMinutes, pointMin);
+                        pointsAvg.Add(pointMinutes, pointAvg / pointCount);
+                        pointsMax.Add(pointMinutes, pointMax);
+                        pointMin = double.MaxValue;
+                        pointMax = 0;
+                        pointAvg = 0;
+                        pointCount = 0;
+                        pointSeconds += 1;
+                    }
+                }
+            }
+
+            for (double x = pointSeconds; x < playlist.TotalLength; x++)
+            {
+                double pointX = (x - 1) / 60;
+                pointsMin.Add(pointX, 0);
+                pointsAvg.Add(pointX, 0);
+                pointsMax.Add(pointX, 0);
+            }
+
+            LineItem avgCurve = GraphControl.GraphPane.AddCurve(
+                "Avg", pointsAvg, Color.Gray, SymbolType.None);
+            avgCurve.Line.IsSmooth = true;
+
+            LineItem minCurve = GraphControl.GraphPane.AddCurve(
+                "Min", pointsMin, Color.LightGray, SymbolType.None);
+            minCurve.Line.IsSmooth = true;
+            minCurve.Line.Fill = new Fill(Color.White);
+
+            LineItem maxCurve = GraphControl.GraphPane.AddCurve(
+                "Max", pointsMax, Color.LightGray, SymbolType.None);
+            maxCurve.Line.IsSmooth = true;
+            maxCurve.Line.Fill = new Fill(Color.LightGray);
+
+            GraphControl.GraphPane.XAxis.Scale.Min = 0;
+            GraphControl.GraphPane.XAxis.Scale.Max = playlist.TotalLength / 60;
+            GraphControl.GraphPane.YAxis.Scale.Min = 0;
+            GraphControl.GraphPane.Y2Axis.Scale.Min = 0;
+            GraphControl.GraphPane.Y2Axis.IsVisible = true;
+
+            GraphControl.AxisChange();
+        }
+
         public void GenerateFrameTypeChart(
             TSPlaylistFile playlist,
             ushort PID,
@@ -564,6 +875,165 @@ namespace BDInfo
                 GraphControl.GraphPane.Chart.Fill.Type = FillType.None;
                 GraphControl.GraphPane.XAxis.IsVisible = false;
                 GraphControl.GraphPane.YAxis.IsVisible = false;
+
+                int drgb = (int)Math.Truncate(255.0 / labels.Length);
+                int rgb = 0;
+
+                List<SortableFrameCount> sortedFrameCounts = new List<SortableFrameCount>();
+                foreach (string frameType in frameCount.Keys)
+                {
+                    sortedFrameCounts.Add(new SortableFrameCount(frameType, frameCount[frameType]));
+                }
+                sortedFrameCounts.Sort();
+
+                int j = sortedFrameCounts.Count;
+                for (int i = 0; i < j; i++)
+                {
+                    AddPieSlice(sortedFrameCounts[i].Name, sortedFrameCounts[i].Count, totalFrameCount, rgb);
+                    rgb += drgb;
+                    if (--j > i)
+                    {
+                        AddPieSlice(sortedFrameCounts[j].Name, sortedFrameCounts[j].Count, totalFrameCount, rgb);
+                        rgb += drgb;
+                    }
+                }
+                GraphControl.GraphPane.AxisChange();
+            }
+
+            GraphControl.IsShowHScrollBar = false;
+            GraphControl.IsAutoScrollRange = false;
+            GraphControl.IsEnableHPan = false;
+            GraphControl.IsEnableHZoom = false;
+            GraphControl.IsEnableSelection = false;
+            GraphControl.IsEnableWheelZoom = false;
+        }
+
+        private void GenerateFrameTypeChart(
+            SavedPlaylistData playlist,
+            SavedVideoStreamData stream,
+            int angleIndex,
+            bool isSizes)
+        {
+            IsHoverDisabled = true;
+
+            GraphControl.GraphPane.XAxis.Title.Text = "Frame Type";
+
+            if (isSizes)
+            {
+                UnitText = "KB";
+                GraphControl.GraphPane.YAxis.Title.Text = "Average / Peak Size (KB)";
+            }
+            else
+            {
+                UnitText = string.Empty;
+                GraphControl.GraphPane.YAxis.Title.Text = "Count";
+            }
+
+            Dictionary<string, double> frameCount = new Dictionary<string, double>();
+            Dictionary<string, double> frameSizes = new Dictionary<string, double>();
+            Dictionary<string, double> framePeaks = new Dictionary<string, double>();
+
+            foreach (SavedStreamClipData clip in playlist.Clips)
+            {
+                if (clip.AngleIndex != angleIndex)
+                {
+                    continue;
+                }
+
+                List<SavedStreamDiagnosticsData> diagList = GetDiagnostics(clip, stream.PID);
+                if (diagList == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < diagList.Count; i++)
+                {
+                    SavedStreamDiagnosticsData diag = diagList[i];
+                    if (diag.Tag == null)
+                    {
+                        continue;
+                    }
+
+                    string frameType = diag.Tag;
+                    double frameSize = diag.Bytes / 1024.0;
+
+                    if (!framePeaks.ContainsKey(frameType))
+                    {
+                        framePeaks[frameType] = frameSize;
+                    }
+                    else if (frameSize > framePeaks[frameType])
+                    {
+                        framePeaks[frameType] = frameSize;
+                    }
+                    if (!frameCount.ContainsKey(frameType))
+                    {
+                        frameCount[frameType] = 0;
+                    }
+                    frameCount[frameType]++;
+
+                    if (!frameSizes.ContainsKey(frameType))
+                    {
+                        frameSizes[frameType] = 0;
+                    }
+                    frameSizes[frameType] += frameSize;
+                }
+            }
+
+            string[] labels = new string[frameCount.Keys.Count];
+            double[] values = new double[frameCount.Keys.Count];
+            double[] peaks = new double[frameCount.Keys.Count];
+            Dictionary<string, int> frameTypes = new Dictionary<string, int>();
+
+            frameCount.Keys.CopyTo(labels, 0);
+
+            double totalFrameCount = 0;
+            for (int i = 0; i < labels.Length; i++)
+            {
+                string label = labels[i];
+                frameTypes[label] = i;
+                if (isSizes)
+                {
+                    values[i] = frameSizes[label] / frameCount[label];
+                    peaks[i] = framePeaks[label];
+                }
+                else
+                {
+                    values[i] = frameCount[label];
+                }
+                totalFrameCount += frameCount[label];
+            }
+
+            if (isSizes)
+            {
+                BarItem barItem = GraphControl.GraphPane.AddBar(
+                    "Average", null, values, Color.Black);
+                barItem.Bar.Fill.Type = FillType.Solid;
+
+                BarItem barItemMax = GraphControl.GraphPane.AddBar(
+                    "Peak", null, peaks, Color.Black);
+                barItemMax.Bar.Fill.Type = FillType.None;
+
+                GraphControl.GraphPane.XAxis.MajorTic.IsBetweenLabels = true;
+                GraphControl.GraphPane.XAxis.Scale.TextLabels = labels;
+                GraphControl.GraphPane.XAxis.Type = AxisType.Text;
+                GraphControl.AxisChange();
+
+                GraphControl.GraphPane.YAxis.Scale.Max +=
+                    GraphControl.GraphPane.YAxis.Scale.MajorStep;
+
+                BarItem.CreateBarLabels(GraphControl.GraphPane, false, "f0");
+                GraphControl.GraphPane.Legend.IsVisible = true;
+            }
+            else
+            {
+                GraphControl.GraphPane.Chart.Fill.Type = FillType.None;
+                GraphControl.GraphPane.XAxis.IsVisible = false;
+                GraphControl.GraphPane.YAxis.IsVisible = false;
+
+                if (labels.Length == 0)
+                {
+                    return;
+                }
 
                 int drgb = (int)Math.Truncate(255.0 / labels.Length);
                 int rgb = 0;

--- a/BDInfo/FormMain.Designer.cs
+++ b/BDInfo/FormMain.Designer.cs
@@ -59,6 +59,7 @@ namespace BDInfo
             this.labelPlaylistFiles = new System.Windows.Forms.Label();
             this.buttonViewReport = new System.Windows.Forms.Button();
             this.buttonScan = new System.Windows.Forms.Button();
+            this.buttonOpenSavedReport = new System.Windows.Forms.Button();
             this.textBoxDetails = new System.Windows.Forms.TextBox();
             this.labelProgress = new System.Windows.Forms.Label();
             this.buttonSelectAll = new System.Windows.Forms.Button();
@@ -208,9 +209,9 @@ namespace BDInfo
             this.buttonViewReport.Text = "View Report...";
             this.buttonViewReport.UseVisualStyleBackColor = true;
             this.buttonViewReport.Click += new System.EventHandler(this.buttonViewReport_Click);
-            // 
+            //
             // buttonScan
-            // 
+            //
             this.buttonScan.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonScan.Enabled = false;
             this.buttonScan.Location = new System.Drawing.Point(368, 548);
@@ -220,6 +221,17 @@ namespace BDInfo
             this.buttonScan.Text = "Scan Bitrates";
             this.buttonScan.UseVisualStyleBackColor = true;
             this.buttonScan.Click += new System.EventHandler(this.buttonScan_Click);
+            //
+            // buttonOpenSavedReport
+            //
+            this.buttonOpenSavedReport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOpenSavedReport.Location = new System.Drawing.Point(599, 548);
+            this.buttonOpenSavedReport.Name = "buttonOpenSavedReport";
+            this.buttonOpenSavedReport.Size = new System.Drawing.Size(108, 23);
+            this.buttonOpenSavedReport.TabIndex = 13;
+            this.buttonOpenSavedReport.Text = "Open Saved...";
+            this.buttonOpenSavedReport.UseVisualStyleBackColor = true;
+            this.buttonOpenSavedReport.Click += new System.EventHandler(this.buttonOpenSavedReport_Click);
             // 
             // textBoxDetails
             // 
@@ -490,6 +502,7 @@ namespace BDInfo
             this.Controls.Add(this.buttonSelectAll);
             this.Controls.Add(this.labelProgress);
             this.Controls.Add(this.buttonSettings);
+            this.Controls.Add(this.buttonOpenSavedReport);
             this.Controls.Add(this.labelTimeRemainingElapsed);
             this.Controls.Add(this.labelTimeDivider);
             this.Controls.Add(this.labelTimeElapsed);
@@ -540,6 +553,7 @@ namespace BDInfo
         private System.Windows.Forms.Label labelPlaylistFiles;
         private System.Windows.Forms.Button buttonViewReport;
         private System.Windows.Forms.Button buttonScan;
+        private System.Windows.Forms.Button buttonOpenSavedReport;
         private System.Windows.Forms.TextBox textBoxDetails;
         private System.Windows.Forms.Label labelProgress;
         private System.Windows.Forms.Button buttonSelectAll;

--- a/BDInfo/FormMain.Designer.cs
+++ b/BDInfo/FormMain.Designer.cs
@@ -225,7 +225,7 @@ namespace BDInfo
             // buttonOpenSavedReport
             //
             this.buttonOpenSavedReport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonOpenSavedReport.Location = new System.Drawing.Point(599, 548);
+            this.buttonOpenSavedReport.Location = new System.Drawing.Point(551, 548);
             this.buttonOpenSavedReport.Name = "buttonOpenSavedReport";
             this.buttonOpenSavedReport.Size = new System.Drawing.Size(108, 23);
             this.buttonOpenSavedReport.TabIndex = 13;

--- a/BDInfo/FormMain.cs
+++ b/BDInfo/FormMain.cs
@@ -276,14 +276,46 @@ namespace BDInfo
         }
 
         private void buttonViewReport_Click(
-            object sender, 
+            object sender,
             EventArgs e)
         {
             GenerateReport();
         }
 
+        private void buttonOpenSavedReport_Click(
+            object sender,
+            EventArgs e)
+        {
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Filter = "BDInfo Reports (*.txt)|*.txt|All Files (*.*)|*.*";
+                dialog.Title = "Open Saved Report";
+                dialog.InitialDirectory = Environment.CurrentDirectory;
+
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    try
+                    {
+                        FormReport report = new FormReport();
+                        report.LoadSavedReport(dialog.FileName);
+                        report.Show();
+                    }
+                    catch (Exception ex)
+                    {
+                        string msg = string.Format(CultureInfo.InvariantCulture,
+                            "Error opening report {0}: {1}",
+                            dialog.FileName,
+                            ex.Message);
+
+                        MessageBox.Show(msg, "BDInfo Error",
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            }
+        }
+
         private void listViewPlaylistFiles_SelectedIndexChanged(
-            object sender, 
+            object sender,
             EventArgs e)
         {
             LoadPlaylist();

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -73,6 +73,7 @@ namespace BDInfo
             textBoxReport.Text = "";
 
             string report = "";
+            SavedReportData autosaveMetadata = null;
             string protection = (BDROM.IsBDPlus ? "BD+" : BDROM.IsUHD ? "AACS2" : "AACS");
 
             if (!string.IsNullOrEmpty(BDROM.DiscTitle))
@@ -1115,11 +1116,28 @@ namespace BDInfo
                 GC.Collect();
             }
 
+            if (BDInfoSettings.AutosaveReport)
+            {
+                try
+                {
+                    autosaveMetadata = ReportPersistence.Capture(BDROM, playlists);
+                }
+                catch
+                {
+                    autosaveMetadata = null;
+                }
+            }
+
             if (BDInfoSettings.AutosaveReport && reportFile != null)
             {
                 try { reportFile.Write(report); }
                 catch { }
 
+                if (autosaveMetadata != null)
+                {
+                    try { reportFile.Write(ReportPersistence.CreateEmbeddedMetadataBlock(autosaveMetadata)); }
+                    catch { }
+                }
             }
             textBoxReport.Text += report;
 
@@ -1132,7 +1150,14 @@ namespace BDInfo
             {
                 try
                 {
-                    ReportPersistence.Save(autosavePath, BDROM, playlists);
+                    if (autosaveMetadata != null)
+                    {
+                        ReportPersistence.Save(autosavePath, autosaveMetadata);
+                    }
+                    else
+                    {
+                        ReportPersistence.Save(autosavePath, BDROM, playlists);
+                    }
                 }
                 catch
                 {
@@ -1161,10 +1186,21 @@ namespace BDInfo
 
             try
             {
-                textBoxReport.Text = File.ReadAllText(filePath);
+                string rawReport = File.ReadAllText(filePath);
+                string displayReport = rawReport;
                 Text = string.Format(CultureInfo.InvariantCulture, "BDInfo Report - {0}", Path.GetFileName(filePath));
 
-                SavedReport = ReportPersistence.Load(filePath);
+                SavedReportData embeddedReport;
+                if (ReportPersistence.TryExtractEmbeddedMetadata(rawReport, out displayReport, out embeddedReport) && embeddedReport != null)
+                {
+                    SavedReport = embeddedReport;
+                }
+                else
+                {
+                    SavedReport = ReportPersistence.Load(filePath);
+                }
+
+                textBoxReport.Text = displayReport;
                 if (SavedReport != null && SavedReport.Playlists.Count > 0)
                 {
                     foreach (SavedPlaylistData playlist in SavedReport.Playlists)

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace BDInfo
@@ -28,6 +29,9 @@ namespace BDInfo
     public partial class FormReport : Form
     {
         private List<TSPlaylistFile> Playlists;
+        private SavedReportData SavedReport;
+        private SavedPlaylistSelection SavedPlaylistSelection => comboBoxPlaylist.SelectedItem as SavedPlaylistSelection;
+        private SavedVideoStreamSelection SavedStreamSelection => comboBoxStream.SelectedItem as SavedVideoStreamSelection;
 
         public string ReportText
         {
@@ -45,6 +49,7 @@ namespace BDInfo
             ScanBDROMResult scanResult)
         {
             Playlists = playlists;
+            SavedReport = null;
 
             comboBoxPlaylist.Enabled = true;
             comboBoxAngle.Enabled = true;
@@ -53,6 +58,7 @@ namespace BDInfo
             buttonChart.Enabled = true;
 
             StreamWriter reportFile = null;
+            string autosavePath = null;
             if (BDInfoSettings.AutosaveReport)
             {
                 string reportName = string.Format(  CultureInfo.InvariantCulture,
@@ -60,8 +66,9 @@ namespace BDInfo
                                                     BDROM.VolumeLabel);
 
                 reportName = ToolBox.GetSafeFileName(reportName);
-                
-                reportFile = File.CreateText(Path.Combine(Environment.CurrentDirectory, reportName));
+
+                autosavePath = Path.Combine(Environment.CurrentDirectory, reportName);
+                reportFile = File.CreateText(autosavePath);
             }
             textBoxReport.Text = "";
 
@@ -1121,6 +1128,17 @@ namespace BDInfo
                 reportFile.Close();
             }
 
+            if (!string.IsNullOrEmpty(autosavePath))
+            {
+                try
+                {
+                    ReportPersistence.Save(autosavePath, BDROM, playlists);
+                }
+                catch
+                {
+                }
+            }
+
             textBoxReport.Select(0, 0);
             comboBoxPlaylist.SelectedIndex = 0;
             comboBoxChartType.SelectedIndex = 0;
@@ -1129,6 +1147,7 @@ namespace BDInfo
         public void LoadSavedReport(string filePath)
         {
             Playlists = null;
+            SavedReport = null;
 
             comboBoxPlaylist.Items.Clear();
             comboBoxAngle.Items.Clear();
@@ -1144,6 +1163,39 @@ namespace BDInfo
             {
                 textBoxReport.Text = File.ReadAllText(filePath);
                 Text = string.Format(CultureInfo.InvariantCulture, "BDInfo Report - {0}", Path.GetFileName(filePath));
+
+                SavedReport = ReportPersistence.Load(filePath);
+                if (SavedReport != null && SavedReport.Playlists.Count > 0)
+                {
+                    foreach (SavedPlaylistData playlist in SavedReport.Playlists)
+                    {
+                        comboBoxPlaylist.Items.Add(new SavedPlaylistSelection(playlist));
+                    }
+
+                    if (comboBoxPlaylist.Items.Count > 0)
+                    {
+                        comboBoxPlaylist.Enabled = true;
+                        comboBoxChartType.Enabled = true;
+                        comboBoxPlaylist.SelectedIndex = 0;
+
+                        bool hasStreams = SavedReport.Playlists.Any(p => p.VideoStreams.Count > 0);
+                        bool hasChartData = SavedReport.Playlists.Any(p =>
+                            p.VideoStreams.Any(stream =>
+                                p.Clips.Any(clip =>
+                                    clip.Diagnostics.ContainsKey(stream.PID) &&
+                                    clip.Diagnostics[stream.PID] != null &&
+                                    clip.Diagnostics[stream.PID].Count > 0)));
+
+                        comboBoxAngle.Enabled = hasStreams;
+                        comboBoxStream.Enabled = hasStreams;
+                        buttonChart.Enabled = hasChartData;
+
+                        if (comboBoxChartType.Items.Count > 0)
+                        {
+                            comboBoxChartType.SelectedIndex = 0;
+                        }
+                    }
+                }
             }
             catch
             {
@@ -1182,6 +1234,12 @@ namespace BDInfo
                 return;
             }
 
+            if (SavedPlaylistSelection != null)
+            {
+                PopulateSavedPlaylist(SavedPlaylistSelection.Data);
+                return;
+            }
+
             TSPlaylistFile playlist = (TSPlaylistFile)comboBoxPlaylist.SelectedItem;
 
             comboBoxAngle.Items.Clear();
@@ -1206,26 +1264,37 @@ namespace BDInfo
         }
 
         private void buttonChart_Click(
-            object sender, 
+            object sender,
             EventArgs e)
         {
-            if (Playlists == null ||
-                comboBoxPlaylist.SelectedItem == null ||
-                comboBoxStream.SelectedItem == null ||
-                comboBoxAngle.SelectedItem == null ||
+            if (comboBoxAngle.SelectedItem == null ||
                 comboBoxChartType.SelectedItem == null)
             {
                 return;
             }
 
-            TSPlaylistFile playlist = 
+            int angleIndex = (int)comboBoxAngle.SelectedItem;
+            string chartType = comboBoxChartType.SelectedItem.ToString();
+
+            if (SavedReport != null && SavedPlaylistSelection != null && SavedStreamSelection != null)
+            {
+                FormChart savedChart = new FormChart();
+                savedChart.Generate(chartType, SavedReport, SavedPlaylistSelection.Data, SavedStreamSelection.Data, angleIndex);
+                savedChart.Show();
+                return;
+            }
+
+            if (Playlists == null ||
+                comboBoxPlaylist.SelectedItem == null ||
+                comboBoxStream.SelectedItem == null)
+            {
+                return;
+            }
+
+            TSPlaylistFile playlist =
                 (TSPlaylistFile)comboBoxPlaylist.SelectedItem;
             TSVideoStream videoStream =
                 (TSVideoStream)comboBoxStream.SelectedItem;
-            int angleIndex =
-                (int)comboBoxAngle.SelectedItem;
-            string chartType =
-                comboBoxChartType.SelectedItem.ToString();
 
             FormChart chart = new FormChart();
             chart.Generate(
@@ -1235,10 +1304,66 @@ namespace BDInfo
         }
 
         private void FormReport_FormClosed(
-            object sender, 
+            object sender,
             FormClosedEventArgs e)
         {
             GC.Collect();
+        }
+
+        private sealed class SavedPlaylistSelection
+        {
+            public SavedPlaylistSelection(SavedPlaylistData data)
+            {
+                Data = data ?? throw new ArgumentNullException(nameof(data));
+            }
+
+            public SavedPlaylistData Data { get; }
+
+            public override string ToString()
+            {
+                return Data.Name;
+            }
+        }
+
+        private void PopulateSavedPlaylist(SavedPlaylistData playlist)
+        {
+            comboBoxAngle.Items.Clear();
+            int maxAngle = Math.Max(0, playlist.AngleCount);
+            for (int i = 0; i <= maxAngle; i++)
+            {
+                comboBoxAngle.Items.Add(i);
+            }
+
+            if (comboBoxAngle.Items.Count > 0)
+            {
+                comboBoxAngle.SelectedIndex = 0;
+            }
+
+            comboBoxStream.Items.Clear();
+            foreach (SavedVideoStreamData stream in playlist.VideoStreams)
+            {
+                comboBoxStream.Items.Add(new SavedVideoStreamSelection(stream));
+            }
+
+            if (comboBoxStream.Items.Count > 0)
+            {
+                comboBoxStream.SelectedIndex = 0;
+            }
+        }
+
+        private sealed class SavedVideoStreamSelection
+        {
+            public SavedVideoStreamSelection(SavedVideoStreamData data)
+            {
+                Data = data ?? throw new ArgumentNullException(nameof(data));
+            }
+
+            public SavedVideoStreamData Data { get; }
+
+            public override string ToString()
+            {
+                return Data.DisplayName;
+            }
         }
     }
 }

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -46,6 +46,12 @@ namespace BDInfo
         {
             Playlists = playlists;
 
+            comboBoxPlaylist.Enabled = true;
+            comboBoxAngle.Enabled = true;
+            comboBoxStream.Enabled = true;
+            comboBoxChartType.Enabled = true;
+            buttonChart.Enabled = true;
+
             StreamWriter reportFile = null;
             if (BDInfoSettings.AutosaveReport)
             {
@@ -1120,6 +1126,32 @@ namespace BDInfo
             comboBoxChartType.SelectedIndex = 0;
         }
 
+        public void LoadSavedReport(string filePath)
+        {
+            Playlists = null;
+
+            comboBoxPlaylist.Items.Clear();
+            comboBoxAngle.Items.Clear();
+            comboBoxStream.Items.Clear();
+
+            comboBoxPlaylist.Enabled = false;
+            comboBoxAngle.Enabled = false;
+            comboBoxStream.Enabled = false;
+            comboBoxChartType.Enabled = false;
+            buttonChart.Enabled = false;
+
+            try
+            {
+                textBoxReport.Text = File.ReadAllText(filePath);
+                Text = string.Format(CultureInfo.InvariantCulture, "BDInfo Report - {0}", Path.GetFileName(filePath));
+            }
+            catch
+            {
+                textBoxReport.Text = string.Empty;
+                throw;
+            }
+        }
+
         private void buttonCopy_Click(
             object sender, 
             EventArgs e)
@@ -1145,6 +1177,11 @@ namespace BDInfo
 
         private void comboBoxPlaylist_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (!comboBoxPlaylist.Enabled || comboBoxPlaylist.SelectedItem == null)
+            {
+                return;
+            }
+
             TSPlaylistFile playlist = (TSPlaylistFile)comboBoxPlaylist.SelectedItem;
 
             comboBoxAngle.Items.Clear();

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -30,7 +30,7 @@ namespace BDInfo
     {
         private List<TSPlaylistFile> Playlists;
         private SavedReportData SavedReport;
-        private SavedPlaylistSelection SavedPlaylistSelection => comboBoxPlaylist.SelectedItem as SavedPlaylistSelection;
+        private SavedPlaylistSelection SelectedSavedPlaylist => comboBoxPlaylist.SelectedItem as SavedPlaylistSelection;
         private SavedVideoStreamSelection SavedStreamSelection => comboBoxStream.SelectedItem as SavedVideoStreamSelection;
 
         public string ReportText
@@ -1234,9 +1234,9 @@ namespace BDInfo
                 return;
             }
 
-            if (SavedPlaylistSelection != null)
+            if (SelectedSavedPlaylist != null)
             {
-                PopulateSavedPlaylist(SavedPlaylistSelection.Data);
+                PopulateSavedPlaylist(SelectedSavedPlaylist.Data);
                 return;
             }
 
@@ -1276,10 +1276,10 @@ namespace BDInfo
             int angleIndex = (int)comboBoxAngle.SelectedItem;
             string chartType = comboBoxChartType.SelectedItem.ToString();
 
-            if (SavedReport != null && SavedPlaylistSelection != null && SavedStreamSelection != null)
+            if (SavedReport != null && SelectedSavedPlaylist != null && SavedStreamSelection != null)
             {
                 FormChart savedChart = new FormChart();
-                savedChart.Generate(chartType, SavedReport, SavedPlaylistSelection.Data, SavedStreamSelection.Data, angleIndex);
+                savedChart.Generate(chartType, SavedReport, SelectedSavedPlaylist.Data, SavedStreamSelection.Data, angleIndex);
                 savedChart.Show();
                 return;
             }

--- a/BDInfo/ReportPersistence.cs
+++ b/BDInfo/ReportPersistence.cs
@@ -9,7 +9,7 @@ using System.Xml;
 namespace BDInfo
 {
     [DataContract]
-    internal class SavedReportData
+    public sealed class SavedReportData
     {
         [DataMember]
         public string VolumeLabel { get; set; }
@@ -19,7 +19,7 @@ namespace BDInfo
     }
 
     [DataContract]
-    internal class SavedPlaylistData
+    public sealed class SavedPlaylistData
     {
         [DataMember]
         public string Name { get; set; }
@@ -38,7 +38,7 @@ namespace BDInfo
     }
 
     [DataContract]
-    internal class SavedVideoStreamData
+    public sealed class SavedVideoStreamData
     {
         [DataMember]
         public ushort PID { get; set; }
@@ -53,7 +53,7 @@ namespace BDInfo
     }
 
     [DataContract]
-    internal class SavedStreamClipData
+    public sealed class SavedStreamClipData
     {
         [DataMember]
         public int AngleIndex { get; set; }
@@ -75,7 +75,7 @@ namespace BDInfo
     }
 
     [DataContract]
-    internal class SavedStreamDiagnosticsData
+    public sealed class SavedStreamDiagnosticsData
     {
         [DataMember]
         public double Marker { get; set; }

--- a/BDInfo/ReportPersistence.cs
+++ b/BDInfo/ReportPersistence.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Xml;
+
+namespace BDInfo
+{
+    [DataContract]
+    internal class SavedReportData
+    {
+        [DataMember]
+        public string VolumeLabel { get; set; }
+
+        [DataMember]
+        public List<SavedPlaylistData> Playlists { get; set; } = new List<SavedPlaylistData>();
+    }
+
+    [DataContract]
+    internal class SavedPlaylistData
+    {
+        [DataMember]
+        public string Name { get; set; }
+
+        [DataMember]
+        public int AngleCount { get; set; }
+
+        [DataMember]
+        public double TotalLength { get; set; }
+
+        [DataMember]
+        public List<SavedVideoStreamData> VideoStreams { get; set; } = new List<SavedVideoStreamData>();
+
+        [DataMember]
+        public List<SavedStreamClipData> Clips { get; set; } = new List<SavedStreamClipData>();
+    }
+
+    [DataContract]
+    internal class SavedVideoStreamData
+    {
+        [DataMember]
+        public ushort PID { get; set; }
+
+        [DataMember]
+        public string DisplayName { get; set; }
+
+        public override string ToString()
+        {
+            return DisplayName;
+        }
+    }
+
+    [DataContract]
+    internal class SavedStreamClipData
+    {
+        [DataMember]
+        public int AngleIndex { get; set; }
+
+        [DataMember]
+        public double TimeIn { get; set; }
+
+        [DataMember]
+        public double RelativeTimeIn { get; set; }
+
+        [DataMember]
+        public double RelativeTimeOut { get; set; }
+
+        [DataMember]
+        public double Length { get; set; }
+
+        [DataMember]
+        public Dictionary<ushort, List<SavedStreamDiagnosticsData>> Diagnostics { get; set; } = new Dictionary<ushort, List<SavedStreamDiagnosticsData>>();
+    }
+
+    [DataContract]
+    internal class SavedStreamDiagnosticsData
+    {
+        [DataMember]
+        public double Marker { get; set; }
+
+        [DataMember]
+        public double Interval { get; set; }
+
+        [DataMember]
+        public ulong Bytes { get; set; }
+
+        [DataMember]
+        public ulong Packets { get; set; }
+
+        [DataMember]
+        public string Tag { get; set; }
+    }
+
+    internal static class ReportPersistence
+    {
+        private const string ReportExtension = ".bdinfo";
+
+        public static void Save(string reportPath, BDROM bdrom, IEnumerable<TSPlaylistFile> playlists)
+        {
+            if (string.IsNullOrWhiteSpace(reportPath))
+            {
+                throw new ArgumentException("reportPath");
+            }
+
+            if (bdrom == null)
+            {
+                throw new ArgumentNullException(nameof(bdrom));
+            }
+
+            if (playlists == null)
+            {
+                throw new ArgumentNullException(nameof(playlists));
+            }
+
+            SavedReportData data = Capture(bdrom, playlists);
+            string metadataPath = GetMetadataPath(reportPath);
+
+            try
+            {
+                using (FileStream stream = File.Create(metadataPath))
+                {
+                    DataContractSerializer serializer = new DataContractSerializer(typeof(SavedReportData));
+                    serializer.WriteObject(stream, data);
+                }
+            }
+            catch
+            {
+                try
+                {
+                    if (File.Exists(metadataPath))
+                    {
+                        File.Delete(metadataPath);
+                    }
+                }
+                catch
+                {
+                }
+
+                throw;
+            }
+        }
+
+        public static SavedReportData Load(string reportPath)
+        {
+            if (string.IsNullOrWhiteSpace(reportPath))
+            {
+                throw new ArgumentException("reportPath");
+            }
+
+            string metadataPath = GetMetadataPath(reportPath);
+            if (!File.Exists(metadataPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                using (FileStream stream = File.OpenRead(metadataPath))
+                {
+                    DataContractSerializer serializer = new DataContractSerializer(typeof(SavedReportData));
+                    return (SavedReportData)serializer.ReadObject(stream);
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static SavedReportData Capture(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists)
+        {
+            SavedReportData data = new SavedReportData
+            {
+                VolumeLabel = bdrom.VolumeLabel
+            };
+
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                SavedPlaylistData playlistData = new SavedPlaylistData
+                {
+                    Name = playlist.Name,
+                    AngleCount = playlist.AngleCount,
+                    TotalLength = playlist.TotalLength
+                };
+
+                foreach (TSVideoStream videoStream in playlist.VideoStreams)
+                {
+                    playlistData.VideoStreams.Add(new SavedVideoStreamData
+                    {
+                        PID = videoStream.PID,
+                        DisplayName = videoStream.ToString()
+                    });
+                }
+
+                foreach (TSStreamClip clip in playlist.StreamClips)
+                {
+                    SavedStreamClipData clipData = new SavedStreamClipData
+                    {
+                        AngleIndex = clip.AngleIndex,
+                        TimeIn = clip.TimeIn,
+                        RelativeTimeIn = clip.RelativeTimeIn,
+                        RelativeTimeOut = clip.RelativeTimeOut,
+                        Length = clip.Length
+                    };
+
+                    if (clip.StreamFile != null && clip.StreamFile.StreamDiagnostics != null)
+                    {
+                        foreach (TSVideoStream videoStream in playlist.VideoStreams)
+                        {
+                            if (!clip.StreamFile.StreamDiagnostics.ContainsKey(videoStream.PID))
+                            {
+                                continue;
+                            }
+
+                            List<TSStreamDiagnostics> diagnostics = clip.StreamFile.StreamDiagnostics[videoStream.PID];
+                            if (diagnostics == null || diagnostics.Count == 0)
+                            {
+                                continue;
+                            }
+
+                            clipData.Diagnostics[videoStream.PID] = diagnostics
+                                .Select(diag => new SavedStreamDiagnosticsData
+                                {
+                                    Marker = diag.Marker,
+                                    Interval = diag.Interval,
+                                    Bytes = diag.Bytes,
+                                    Packets = diag.Packets,
+                                    Tag = diag.Tag
+                                })
+                                .ToList();
+                        }
+                    }
+
+                    playlistData.Clips.Add(clipData);
+                }
+
+                data.Playlists.Add(playlistData);
+            }
+
+            return data;
+        }
+
+        private static string GetMetadataPath(string reportPath)
+        {
+            string directory = Path.GetDirectoryName(reportPath) ?? Environment.CurrentDirectory;
+            string fileName = Path.GetFileNameWithoutExtension(reportPath);
+            string safeFileName = ToolBox.GetSafeFileName(fileName);
+            return Path.Combine(directory, string.Format(CultureInfo.InvariantCulture, "{0}{1}", safeFileName, ReportExtension));
+        }
+    }
+}

--- a/BDInfo/ReportPersistence.cs
+++ b/BDInfo/ReportPersistence.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text;
 using System.Xml;
 
 namespace BDInfo
@@ -97,6 +98,9 @@ namespace BDInfo
     {
         private const string ReportExtension = ".bdinfo";
 
+        internal const string EmbeddedMetadataBeginMarker = "==== BDINFO METADATA BEGIN ====";
+        internal const string EmbeddedMetadataEndMarker = "==== BDINFO METADATA END ====";
+
         public static void Save(string reportPath, BDROM bdrom, IEnumerable<TSPlaylistFile> playlists)
         {
             if (string.IsNullOrWhiteSpace(reportPath))
@@ -115,6 +119,21 @@ namespace BDInfo
             }
 
             SavedReportData data = Capture(bdrom, playlists);
+            Save(reportPath, data);
+        }
+
+        public static void Save(string reportPath, SavedReportData data)
+        {
+            if (string.IsNullOrWhiteSpace(reportPath))
+            {
+                throw new ArgumentException("reportPath");
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
             string metadataPath = GetMetadataPath(reportPath);
 
             try
@@ -169,7 +188,7 @@ namespace BDInfo
             }
         }
 
-        private static SavedReportData Capture(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists)
+        internal static SavedReportData Capture(BDROM bdrom, IEnumerable<TSPlaylistFile> playlists)
         {
             SavedReportData data = new SavedReportData
             {
@@ -240,6 +259,96 @@ namespace BDInfo
             }
 
             return data;
+        }
+
+        internal static string CreateEmbeddedMetadataBlock(SavedReportData data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                DataContractSerializer serializer = new DataContractSerializer(typeof(SavedReportData));
+                serializer.WriteObject(stream, data);
+                string base64 = Convert.ToBase64String(stream.ToArray());
+
+                StringBuilder builder = new StringBuilder();
+                builder.AppendLine();
+                builder.AppendLine(EmbeddedMetadataBeginMarker);
+                builder.AppendLine(base64);
+                builder.AppendLine(EmbeddedMetadataEndMarker);
+                return builder.ToString();
+            }
+        }
+
+        internal static bool TryExtractEmbeddedMetadata(
+            string reportText,
+            out string sanitizedText,
+            out SavedReportData data)
+        {
+            sanitizedText = reportText;
+            data = null;
+
+            if (string.IsNullOrEmpty(reportText))
+            {
+                return false;
+            }
+
+            int footerIndex = reportText.LastIndexOf(EmbeddedMetadataEndMarker, StringComparison.Ordinal);
+            if (footerIndex < 0)
+            {
+                return false;
+            }
+
+            int headerIndex = reportText.LastIndexOf(EmbeddedMetadataBeginMarker, footerIndex, StringComparison.Ordinal);
+            if (headerIndex < 0)
+            {
+                return false;
+            }
+
+            int metadataStart = headerIndex + EmbeddedMetadataBeginMarker.Length;
+            string metadataPayload = reportText.Substring(metadataStart, footerIndex - metadataStart);
+            string base64 = new string(metadataPayload.Where(c => !char.IsWhiteSpace(c)).ToArray());
+
+            if (base64.Length == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                byte[] buffer = Convert.FromBase64String(base64);
+                using (MemoryStream stream = new MemoryStream(buffer))
+                {
+                    DataContractSerializer serializer = new DataContractSerializer(typeof(SavedReportData));
+                    data = (SavedReportData)serializer.ReadObject(stream);
+                }
+            }
+            catch
+            {
+                data = null;
+                return false;
+            }
+
+            int blockEnd = footerIndex + EmbeddedMetadataEndMarker.Length;
+            string beforeBlock = reportText.Substring(0, headerIndex);
+            string afterBlock = blockEnd < reportText.Length
+                ? reportText.Substring(blockEnd)
+                : string.Empty;
+
+            sanitizedText = beforeBlock.TrimEnd('\r', '\n');
+            if (!string.IsNullOrEmpty(afterBlock))
+            {
+                if (sanitizedText.Length > 0)
+                {
+                    sanitizedText += Environment.NewLine;
+                }
+                sanitizedText += afterBlock.TrimStart('\r', '\n');
+            }
+
+            return true;
         }
 
         private static string GetMetadataPath(string reportPath)


### PR DESCRIPTION
## Summary
- add a dedicated button in the main window to open previously saved BDInfo reports
- load saved report files in the report viewer while disabling playlist- and chart-related controls when they are not applicable
- guard playlist selection handling to avoid null references when no playlists are available

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ed6f8b902483249aa448c98dda91d9