### PR TITLE
Add report export and import support

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -107,6 +107,8 @@
     <Compile Include="FormPlaylist.Designer.cs">
       <DependentUpon>FormPlaylist.cs</DependentUpon>
     </Compile>
+    <Compile Include="Report\ReportModels.cs" />
+    <Compile Include="Report\ReportSerializer.cs" />
     <Compile Include="ToolBox.cs" />
     <Compile Include="FormChart.cs">
       <SubType>Form</SubType>

--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -67,6 +67,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/BDInfo/BDROM/BDROM.cs
+++ b/BDInfo/BDROM/BDROM.cs
@@ -62,6 +62,8 @@ namespace BDInfo
         public bool Is3D = false;
         public bool Is50Hz = false;
         public bool IsUHD = false;
+        public bool IsReport { get; internal set; } = false;
+        public string ReportPath { get; internal set; } = null;
 
         public bool IsImage = false;
         public FileStream IoStream = null;
@@ -93,9 +95,15 @@ namespace BDInfo
 
         public event OnPlaylistFileScanError PlaylistFileScanError;
 
+        internal BDROM()
+        {
+            IsReport = true;
+        }
+
         public BDROM(
             string path)
         {
+            IsReport = false;
             //
             // Locate BDMV directories.
             //

--- a/BDInfo/BDROM/TSInterleavedFile.cs
+++ b/BDInfo/BDROM/TSInterleavedFile.cs
@@ -49,5 +49,10 @@ namespace BDInfo
             CdReader = reader;
             Name = fileInfo.Name.ToUpper();
         }
+
+        internal TSInterleavedFile(string name)
+        {
+            Name = name.ToUpperInvariant();
+        }
     }
 }

--- a/BDInfo/BDROM/TSPlaylistFile.cs
+++ b/BDInfo/BDROM/TSPlaylistFile.cs
@@ -128,6 +128,12 @@ namespace BDInfo
             IsInitialized = true;
         }
 
+        internal TSPlaylistFile(BDROM bdrom, string name)
+        {
+            BDROM = bdrom;
+            Name = name.ToUpperInvariant();
+        }
+
         public override string ToString()
         {
             return Name;

--- a/BDInfo/BDROM/TSStreamClip.cs
+++ b/BDInfo/BDROM/TSStreamClip.cs
@@ -55,16 +55,18 @@ namespace BDInfo
                 StreamFile = streamFile;
 
                 if (StreamFile.FileInfo != null)
-                    FileSize = (ulong) StreamFile.FileInfo.Length;
-                else
-                    FileSize = (ulong) StreamFile.DFileInfo.Length;
+                    FileSize = (ulong)StreamFile.FileInfo.Length;
+                else if (StreamFile.DFileInfo != null)
+                    FileSize = (ulong)StreamFile.DFileInfo.Length;
+                else if (StreamFile.Size > 0)
+                    FileSize = (ulong)StreamFile.Size;
 
                 if (StreamFile.InterleavedFile != null)
                 {
                     if (StreamFile.InterleavedFile.FileInfo != null)
-                        InterleavedFileSize = (ulong) StreamFile.InterleavedFile.FileInfo.Length;
-                    else
-                        InterleavedFileSize = (ulong) StreamFile.InterleavedFile.DFileInfo.Length;
+                        InterleavedFileSize = (ulong)StreamFile.InterleavedFile.FileInfo.Length;
+                    else if (StreamFile.InterleavedFile.DFileInfo != null)
+                        InterleavedFileSize = (ulong)StreamFile.InterleavedFile.DFileInfo.Length;
                 }
             }
             StreamClipFile = streamClipFile;

--- a/BDInfo/BDROM/TSStreamClipFile.cs
+++ b/BDInfo/BDROM/TSStreamClipFile.cs
@@ -57,6 +57,12 @@ namespace BDInfo
             Name = fileInfo.Name.ToUpper();
         }
 
+        internal TSStreamClipFile(string name)
+        {
+            Name = name.ToUpperInvariant();
+            IsValid = true;
+        }
+
         public void Scan()
         {
             FileStream fileStream = null;

--- a/BDInfo/BDROM/TSStreamFile.cs
+++ b/BDInfo/BDROM/TSStreamFile.cs
@@ -199,6 +199,13 @@ namespace BDInfo
             Name = fileInfo.Name.ToUpper();
         }
 
+        internal TSStreamFile(string name, long size, double length)
+        {
+            Name = name.ToUpperInvariant();
+            Size = size;
+            Length = length;
+        }
+
         public string DisplayName
         {
             get

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
+using BDInfo.Reporting;
 
 namespace BDInfo
 {
@@ -21,6 +22,12 @@ namespace BDInfo
             "Video Frame Type Sizes"
         };
 
+        private enum ReportFormat
+        {
+            Text,
+            Bdinfo
+        }
+
         private sealed class CliOptions
         {
             public string BdPath;
@@ -31,7 +38,9 @@ namespace BDInfo
             public bool WholeDisc;
             public bool SaveCharts;
             public string ChartFormat = "png";
+            public bool ReportFormatsSpecified;
             public List<string> PlaylistNames { get; } = new List<string>();
+            public HashSet<ReportFormat> ReportFormats { get; } = new HashSet<ReportFormat> { ReportFormat.Text };
         }
 
         public static bool TryHandle(string[] args)
@@ -145,6 +154,35 @@ namespace BDInfo
                     {
                         options.ChartFormat = value;
                     }
+                    continue;
+                }
+
+                if (IsOption(arg, "-r", "--report"))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-r", "--report");
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new ArgumentException("The --report option requires a comma separated list of formats.");
+                    }
+
+                    if (!options.ReportFormatsSpecified)
+                    {
+                        options.ReportFormats.Clear();
+                    }
+
+                    bool anyFormat = false;
+                    foreach (string token in SplitValues(value))
+                    {
+                        options.ReportFormats.Add(ParseReportFormat(token));
+                        anyFormat = true;
+                    }
+
+                    if (!anyFormat)
+                    {
+                        throw new ArgumentException("The --report option did not include any formats.");
+                    }
+
+                    options.ReportFormatsSpecified = true;
                     continue;
                 }
 
@@ -384,8 +422,16 @@ namespace BDInfo
                     throw new InvalidOperationException("Report destination was not resolved.");
                 }
 
-                string reportPath = GenerateReport(bdrom, selectedPlaylists, scanResult, reportDestination);
-                Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report written to: {0}", reportPath));
+                if (options.ReportFormats.Count == 0)
+                {
+                    options.ReportFormats.Add(ReportFormat.Text);
+                }
+
+                List<string> reportPaths = GenerateReports(bdrom, selectedPlaylists, scanResult, reportDestination, options.ReportFormats);
+                foreach (string path in reportPaths)
+                {
+                    Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report written to: {0}", path));
+                }
 
                 if (options.SaveCharts)
                 {
@@ -463,7 +509,10 @@ namespace BDInfo
 
         private static bool NeedsFurtherProcessing(CliOptions options)
         {
-            return options.PlaylistNames.Count > 0 || options.WholeDisc || options.SaveCharts;
+            return options.PlaylistNames.Count > 0
+                   || options.WholeDisc
+                   || options.SaveCharts
+                   || options.ReportFormatsSpecified;
         }
 
         private static void AttachErrorHandlers(BDROM bdrom)
@@ -1025,21 +1074,65 @@ namespace BDInfo
             }
         }
 
-        private static string GenerateReport(BDROM bdrom, List<TSPlaylistFile> playlists, ScanBDROMResult scanResult, string destination)
+        private static List<string> GenerateReports(BDROM bdrom, List<TSPlaylistFile> playlists, ScanBDROMResult scanResult, string destination, IReadOnlyCollection<ReportFormat> formats)
         {
-            using (var report = new FormReport())
+            if (formats == null || formats.Count == 0)
             {
-                report.Generate(bdrom, playlists, scanResult);
-                string reportText = report.ReportText;
+                formats = new[] { ReportFormat.Text };
+            }
 
-                string volumeLabel = string.IsNullOrWhiteSpace(bdrom.VolumeLabel)
-                    ? "UNKNOWN"
-                    : bdrom.VolumeLabel;
+            string volumeLabel = string.IsNullOrWhiteSpace(bdrom.VolumeLabel)
+                ? "UNKNOWN"
+                : bdrom.VolumeLabel;
 
-                string fileName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", volumeLabel));
-                string reportPath = Path.Combine(destination, fileName);
-                File.WriteAllText(reportPath, reportText);
-                return reportPath;
+            string sanitizedTextName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", volumeLabel));
+            string sanitizedBaseName = Path.GetFileNameWithoutExtension(sanitizedTextName);
+
+            if (string.IsNullOrWhiteSpace(sanitizedBaseName))
+            {
+                sanitizedBaseName = "BDINFO";
+            }
+
+            var writtenPaths = new List<string>();
+
+            if (formats.Contains(ReportFormat.Text))
+            {
+                using (var report = new FormReport())
+                {
+                    report.Generate(bdrom, playlists, scanResult);
+                    string reportText = report.ReportText;
+                    string reportPath = Path.Combine(destination, sanitizedTextName);
+                    File.WriteAllText(reportPath, reportText);
+                    writtenPaths.Add(reportPath);
+                }
+            }
+
+            if (formats.Contains(ReportFormat.Bdinfo))
+            {
+                string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
+                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult);
+                writtenPaths.Add(reportPath);
+            }
+
+            return writtenPaths;
+        }
+
+        private static ReportFormat ParseReportFormat(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Report format value cannot be empty.");
+            }
+
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "txt":
+                case "text":
+                    return ReportFormat.Text;
+                case "bdinfo":
+                    return ReportFormat.Bdinfo;
+                default:
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported report format: {0}", value));
             }
         }
 
@@ -1122,6 +1215,7 @@ namespace BDInfo
             Console.WriteLine("  -w, --whole                Scan whole disc - every playlist.");
             Console.WriteLine("  -v, --version              Print the version.");
             Console.WriteLine("  -c, --charts               Save all charts as image (select image format, default png)");
+            Console.WriteLine("  -r, --report              Choose report formats (txt, bdinfo). Use commas for multiple.");
         }
     }
 }

--- a/BDInfo/FormMain.Designer.cs
+++ b/BDInfo/FormMain.Designer.cs
@@ -85,6 +85,7 @@ namespace BDInfo
             this.columnHeaderDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.buttonRescan = new System.Windows.Forms.Button();
             this.buttonIsoBrowse = new System.Windows.Forms.Button();
+            this.buttonLoadReport = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainerOuter)).BeginInit();
             this.splitContainerOuter.Panel1.SuspendLayout();
             this.splitContainerOuter.Panel2.SuspendLayout();
@@ -96,9 +97,9 @@ namespace BDInfo
             this.SuspendLayout();
             // 
             // buttonBrowse
-            // 
+            //
             this.buttonBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonBrowse.Location = new System.Drawing.Point(598, 22);
+            this.buttonBrowse.Location = new System.Drawing.Point(531, 22);
             this.buttonBrowse.Name = "buttonBrowse";
             this.buttonBrowse.Size = new System.Drawing.Size(62, 23);
             this.buttonBrowse.TabIndex = 1;
@@ -112,7 +113,7 @@ namespace BDInfo
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxSource.Location = new System.Drawing.Point(17, 24);
             this.textBoxSource.Name = "textBoxSource";
-            this.textBoxSource.Size = new System.Drawing.Size(575, 20);
+            this.textBoxSource.Size = new System.Drawing.Size(508, 20);
             this.textBoxSource.TabIndex = 0;
             this.textBoxSource.TextChanged += new System.EventHandler(this.textBoxSource_TextChanged);
             // 
@@ -457,10 +458,10 @@ namespace BDInfo
             // 
             this.buttonRescan.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonRescan.Enabled = false;
-            this.buttonRescan.Location = new System.Drawing.Point(706, 22);
+            this.buttonRescan.Location = new System.Drawing.Point(710, 22);
             this.buttonRescan.Name = "buttonRescan";
             this.buttonRescan.Size = new System.Drawing.Size(66, 23);
-            this.buttonRescan.TabIndex = 3;
+            this.buttonRescan.TabIndex = 4;
             this.buttonRescan.Text = "Rescan";
             this.buttonRescan.UseVisualStyleBackColor = true;
             this.buttonRescan.Click += new System.EventHandler(this.buttonRescan_Click);
@@ -468,13 +469,24 @@ namespace BDInfo
             // buttonIsoBrowse
             // 
             this.buttonIsoBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonIsoBrowse.Location = new System.Drawing.Point(666, 22);
+            this.buttonIsoBrowse.Location = new System.Drawing.Point(599, 22);
             this.buttonIsoBrowse.Name = "buttonIsoBrowse";
             this.buttonIsoBrowse.Size = new System.Drawing.Size(34, 23);
             this.buttonIsoBrowse.TabIndex = 2;
             this.buttonIsoBrowse.Text = "ISO";
             this.buttonIsoBrowse.UseVisualStyleBackColor = true;
             this.buttonIsoBrowse.Click += new System.EventHandler(this.buttonBrowse_Click);
+            //
+            // buttonLoadReport
+            //
+            this.buttonLoadReport.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonLoadReport.Location = new System.Drawing.Point(639, 22);
+            this.buttonLoadReport.Name = "buttonLoadReport";
+            this.buttonLoadReport.Size = new System.Drawing.Size(65, 23);
+            this.buttonLoadReport.TabIndex = 3;
+            this.buttonLoadReport.Text = "Report...";
+            this.buttonLoadReport.UseVisualStyleBackColor = true;
+            this.buttonLoadReport.Click += new System.EventHandler(this.buttonBrowse_Click);
             // 
             // FormMain
             // 
@@ -482,6 +494,7 @@ namespace BDInfo
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(784, 575);
+            this.Controls.Add(this.buttonLoadReport);
             this.Controls.Add(this.buttonIsoBrowse);
             this.Controls.Add(this.buttonRescan);
             this.Controls.Add(this.splitContainerOuter);
@@ -566,5 +579,6 @@ namespace BDInfo
         private System.Windows.Forms.ColumnHeader columnHeaderPlaylistGroup;
         private System.Windows.Forms.ColumnHeader columnHeaderIndex;
         private System.Windows.Forms.Button buttonIsoBrowse;
+        private System.Windows.Forms.Button buttonLoadReport;
     }
 }

--- a/BDInfo/FormMain.cs
+++ b/BDInfo/FormMain.cs
@@ -24,9 +24,11 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using BDInfo.Reporting;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace BDInfo
@@ -129,14 +131,9 @@ namespace BDInfo
 
         private void textBoxSource_TextChanged(object sender, EventArgs e)
         {
-            if (textBoxSource.Text.Length > 0)
-            {
-                buttonRescan.Enabled = true;
-            }
-            else
-            {
-                buttonRescan.Enabled = false;
-            }
+            bool hasText = textBoxSource.Text.Length > 0;
+            bool isReport = BDROM != null && BDROM.IsReport;
+            buttonRescan.Enabled = hasText && !isReport;
         }
 
         private void FormMain_DragEnter(object sender, DragEventArgs e)
@@ -174,6 +171,12 @@ namespace BDInfo
                 {
                     openDialog.IsFolderPicker = true;
                     openDialog.Title = "Select a BluRay BDMV Folder:";
+                }
+                else if (((Button) sender).Name == "buttonLoadReport")
+                {
+                    openDialog.IsFolderPicker = false;
+                    openDialog.Title = "Select a BDInfo report file:";
+                    openDialog.Filters.Add(new CommonFileDialogFilter("BDInfo Report", "bdinfo"));
                 }
                 else
                 {
@@ -390,6 +393,18 @@ namespace BDInfo
 
         private BackgroundWorker InitBDROMWorker = null;
 
+        private class InitBDROMParameters
+        {
+            public string Path;
+            public bool IsReport;
+        }
+
+        private class InitBDROMResult
+        {
+            public Exception Exception;
+            public BDInfoReportData ReportData;
+        }
+
         private void InitBDROM(
             string path)
         {
@@ -398,6 +413,7 @@ namespace BDInfo
             CustomPlaylistCount = 0;
             buttonBrowse.Enabled = false;
             buttonIsoBrowse.Enabled = false;
+            buttonLoadReport.Enabled = false;
             buttonRescan.Enabled = false;
             buttonSelectAll.Enabled = false;
             buttonUnselectAll.Enabled = false;
@@ -422,25 +438,55 @@ namespace BDInfo
             InitBDROMWorker.DoWork += InitBDROMWork;
             InitBDROMWorker.ProgressChanged += InitBDROMProgress;
             InitBDROMWorker.RunWorkerCompleted += InitBDROMCompleted;
-            InitBDROMWorker.RunWorkerAsync(path);
+            bool isReport = false;
+            try
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    isReport = string.Equals(Path.GetExtension(path), ".bdinfo", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            catch
+            {
+                isReport = false;
+            }
+
+            var parameters = new InitBDROMParameters { Path = path, IsReport = isReport };
+
+            InitBDROMWorker.RunWorkerAsync(parameters);
         }
 
         private void InitBDROMWork(
-            object sender, 
+            object sender,
             DoWorkEventArgs e)
         {
             try
             {
-                BDROM = new BDROM((string)e.Argument);
-                BDROM.StreamClipFileScanError += new BDROM.OnStreamClipFileScanError(BDROM_StreamClipFileScanError);
-                BDROM.StreamFileScanError += new BDROM.OnStreamFileScanError(BDROM_StreamFileScanError);
-                BDROM.PlaylistFileScanError += new BDROM.OnPlaylistFileScanError(BDROM_PlaylistFileScanError);
-                BDROM.Scan();
-                e.Result = null;
+                InitBDROMParameters parameters = e.Argument as InitBDROMParameters;
+                string path = parameters?.Path ?? e.Argument as string;
+                bool isReport = parameters?.IsReport ?? false;
+
+                if (isReport)
+                {
+                    BDInfoReportData reportData = BDInfoReportSerializer.Load(path);
+                    BDROM = BDInfoReportSerializer.CreateBDROM(reportData);
+                    ScanResult = BDInfoReportSerializer.CreateScanResult(reportData.ScanResult);
+                    e.Result = new InitBDROMResult { ReportData = reportData };
+                }
+                else
+                {
+                    BDROM = new BDROM(path);
+                    BDROM.StreamClipFileScanError += new BDROM.OnStreamClipFileScanError(BDROM_StreamClipFileScanError);
+                    BDROM.StreamFileScanError += new BDROM.OnStreamFileScanError(BDROM_StreamFileScanError);
+                    BDROM.PlaylistFileScanError += new BDROM.OnPlaylistFileScanError(BDROM_PlaylistFileScanError);
+                    BDROM.Scan();
+                    ScanResult = new ScanBDROMResult();
+                    e.Result = new InitBDROMResult();
+                }
             }
             catch (Exception ex)
             {
-                e.Result = ex;
+                e.Result = new InitBDROMResult { Exception = ex };
             }
         }
 
@@ -481,28 +527,32 @@ namespace BDInfo
         }
 
         private void InitBDROMCompleted(
-            object sender, 
+            object sender,
             RunWorkerCompletedEventArgs e)
         {
             HideNotification();
 
-            if (e.Result != null)
+            InitBDROMResult result = e.Result as InitBDROMResult;
+            Exception exception = result?.Exception ?? (e.Result as Exception);
+
+            if (exception != null)
             {
-                string msg = string.Format(CultureInfo.InvariantCulture,
-                                            "{0}", ((Exception)e.Result).Message);
+                string msg = string.Format(CultureInfo.InvariantCulture, "{0}", exception.Message);
 
                 MessageBox.Show(msg, "BDInfo Error",
                                             MessageBoxButtons.OK, MessageBoxIcon.Error);
                 buttonBrowse.Enabled = true;
                 buttonIsoBrowse.Enabled = true;
+                buttonLoadReport.Enabled = true;
                 buttonRescan.Enabled = true;
                 return;
             }
 
             buttonBrowse.Enabled = true;
             buttonIsoBrowse.Enabled = true;
-            buttonRescan.Enabled = true;
-            buttonScan.Enabled = true;
+            buttonLoadReport.Enabled = true;
+            buttonRescan.Enabled = !(BDROM?.IsReport ?? false);
+            buttonScan.Enabled = !(BDROM?.IsReport ?? false);
             buttonSelectAll.Enabled = true;
             buttonUnselectAll.Enabled = true;
             buttonCustomPlaylist.Enabled = true;
@@ -524,7 +574,14 @@ namespace BDInfo
                                                     Environment.NewLine);
             }
 
-            if (!BDROM.IsImage)
+            if (BDROM.IsReport)
+            {
+                textBoxDetails.Text += string.Format(CultureInfo.InvariantCulture,
+                                                    "Loaded BDInfo report: {0}{1}",
+                                                    string.IsNullOrEmpty(BDROM.ReportPath) ? textBoxSource.Text : BDROM.ReportPath,
+                                                    Environment.NewLine);
+            }
+            else if (!BDROM.IsImage)
             {
                 textBoxSource.Text = BDROM.DirectoryRoot.FullName;
                 textBoxDetails.Text += string.Format(CultureInfo.InvariantCulture,
@@ -1068,6 +1125,16 @@ namespace BDInfo
                 ScanBDROMWorker.IsBusy)
             {
                 ScanBDROMWorker.CancelAsync();
+                return;
+            }
+
+            if (BDROM != null && BDROM.IsReport)
+            {
+                MessageBox.Show(this,
+                    "Scanning is not available for exported reports.",
+                    "BDInfo",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
                 return;
             }
 

--- a/BDInfo/FormReport.Designer.cs
+++ b/BDInfo/FormReport.Designer.cs
@@ -48,6 +48,7 @@ namespace BDInfo
         private void InitializeComponent()
         {
             this.buttonCopy = new System.Windows.Forms.Button();
+            this.buttonExport = new System.Windows.Forms.Button();
             this.textBoxReport = new System.Windows.Forms.TextBox();
             this.buttonChart = new System.Windows.Forms.Button();
             this.labelChartType = new System.Windows.Forms.Label();
@@ -61,7 +62,7 @@ namespace BDInfo
             this.SuspendLayout();
             // 
             // buttonCopy
-            // 
+            //
             this.buttonCopy.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.buttonCopy.Location = new System.Drawing.Point(285, 457);
             this.buttonCopy.Name = "buttonCopy";
@@ -70,6 +71,17 @@ namespace BDInfo
             this.buttonCopy.Text = "Copy to Clipboard";
             this.buttonCopy.UseVisualStyleBackColor = true;
             this.buttonCopy.Click += new System.EventHandler(this.buttonCopy_Click);
+            //
+            // buttonExport
+            //
+            this.buttonExport.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.buttonExport.Location = new System.Drawing.Point(157, 457);
+            this.buttonExport.Name = "buttonExport";
+            this.buttonExport.Size = new System.Drawing.Size(122, 23);
+            this.buttonExport.TabIndex = 7;
+            this.buttonExport.Text = "Export Report...";
+            this.buttonExport.UseVisualStyleBackColor = true;
+            this.buttonExport.Click += new System.EventHandler(this.buttonExport_Click);
             // 
             // textBoxReport
             // 
@@ -191,6 +203,7 @@ namespace BDInfo
             this.Controls.Add(this.comboBoxAngle);
             this.Controls.Add(this.labelPlaylist);
             this.Controls.Add(this.comboBoxPlaylist);
+            this.Controls.Add(this.buttonExport);
             this.Controls.Add(this.buttonCopy);
             this.Controls.Add(this.textBoxReport);
             this.Name = "FormReport";
@@ -214,6 +227,7 @@ namespace BDInfo
         private System.Windows.Forms.ComboBox comboBoxAngle;
         private System.Windows.Forms.Label labelPlaylist;
         private System.Windows.Forms.ComboBox comboBoxPlaylist;
+        private System.Windows.Forms.Button buttonExport;
 
     }
 }

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -22,12 +22,16 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Windows.Forms;
+using BDInfo.Reporting;
 
 namespace BDInfo
 {
     public partial class FormReport : Form
     {
         private List<TSPlaylistFile> Playlists;
+        private BDROM ReportBDROM;
+        private List<TSPlaylistFile> ReportPlaylists = new List<TSPlaylistFile>();
+        private ScanBDROMResult ReportScanResult;
 
         public string ReportText
         {
@@ -45,6 +49,10 @@ namespace BDInfo
             ScanBDROMResult scanResult)
         {
             Playlists = playlists;
+            ReportBDROM = BDROM;
+            ReportPlaylists = playlists != null ? new List<TSPlaylistFile>(playlists) : new List<TSPlaylistFile>();
+            ReportScanResult = scanResult;
+            buttonExport.Enabled = ReportBDROM != null && ReportPlaylists.Count > 0;
 
             StreamWriter reportFile = null;
             if (BDInfoSettings.AutosaveReport)
@@ -1121,14 +1129,64 @@ namespace BDInfo
         }
 
         private void buttonCopy_Click(
-            object sender, 
+            object sender,
             EventArgs e)
         {
             Clipboard.SetText(textBoxReport.Text);
         }
 
+        private void buttonExport_Click(
+            object sender,
+            EventArgs e)
+        {
+            if (ReportBDROM == null || ReportPlaylists == null || ReportPlaylists.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "There is no report data available to export.",
+                    "BDInfo",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return;
+            }
+
+            string defaultName = ReportBDROM.VolumeLabel;
+            if (string.IsNullOrWhiteSpace(defaultName))
+            {
+                defaultName = "BDINFO";
+            }
+            defaultName = ToolBox.GetSafeFileName(defaultName) + ".bdinfo";
+
+            using (SaveFileDialog dialog = new SaveFileDialog())
+            {
+                dialog.Filter = "BDInfo Report (*.bdinfo)|*.bdinfo|All files (*.*)|*.*";
+                dialog.DefaultExt = "bdinfo";
+                dialog.FileName = defaultName;
+
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    try
+                    {
+                        BDInfoReportSerializer.Save(dialog.FileName, ReportBDROM, ReportPlaylists, ReportScanResult);
+                        MessageBox.Show(this,
+                            "Report exported successfully.",
+                            "BDInfo",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Information);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(this,
+                            string.Format(CultureInfo.InvariantCulture, "Error exporting report: {0}", ex.Message),
+                            "BDInfo Error",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                    }
+                }
+            }
+        }
+
         private void textBoxReport_KeyDown(
-            object sender, 
+            object sender,
             KeyEventArgs e)
         {
             if (e.Control && (e.KeyCode == System.Windows.Forms.Keys.A))

--- a/BDInfo/Report/ReportModels.cs
+++ b/BDInfo/Report/ReportModels.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using BDInfo;
+
+namespace BDInfo.Reporting
+{
+    [DataContract]
+    [KnownType(typeof(VideoStreamData))]
+    [KnownType(typeof(AudioStreamData))]
+    [KnownType(typeof(TextStreamData))]
+    [KnownType(typeof(GraphicsStreamData))]
+    public class StreamData
+    {
+        [DataMember] public ushort PID;
+        [DataMember] public TSStreamType StreamType;
+        [DataMember] public bool IsVBR;
+        [DataMember] public long BitRate;
+        [DataMember] public long ActiveBitRate;
+        [DataMember] public bool IsInitialized;
+        [DataMember] public string LanguageCode;
+        [DataMember] public string LanguageName;
+        [DataMember] public bool IsHidden;
+        [DataMember] public ulong PayloadBytes;
+        [DataMember] public ulong PacketCount;
+        [DataMember] public double PacketSeconds;
+        [DataMember] public int AngleIndex;
+        [DataMember] public bool? BaseView;
+        [DataMember] public string ExtendedData;
+        [DataMember] public bool HasExtensions;
+        [DataMember] public TSAudioMode AudioMode;
+        [DataMember] public TSChannelLayout ChannelLayout;
+        [DataMember] public ushort? CoreStreamPID;
+        [DataMember] public int SampleRate;
+        [DataMember] public int ChannelCount;
+        [DataMember] public int BitDepth;
+        [DataMember] public int LFE;
+        [DataMember] public int DialNorm;
+        [DataMember] public int Width;
+        [DataMember] public int Height;
+        [DataMember] public bool IsInterlaced;
+        [DataMember] public int FrameRateEnumerator;
+        [DataMember] public int FrameRateDenominator;
+        [DataMember] public TSAspectRatio AspectRatio;
+        [DataMember] public TSVideoFormat VideoFormat;
+        [DataMember] public TSFrameRate FrameRate;
+        [DataMember] public string EncodingProfile;
+        [DataMember] public int Captions;
+        [DataMember] public int ForcedCaptions;
+    }
+
+    [DataContract]
+    public class VideoStreamData : StreamData
+    {
+    }
+
+    [DataContract]
+    public class AudioStreamData : StreamData
+    {
+    }
+
+    [DataContract]
+    public class TextStreamData : StreamData
+    {
+    }
+
+    [DataContract]
+    public class GraphicsStreamData : StreamData
+    {
+    }
+
+    [DataContract]
+    public class StreamDiagnosticsData
+    {
+        [DataMember] public double Marker;
+        [DataMember] public double Interval;
+        [DataMember] public ulong Bytes;
+        [DataMember] public ulong Packets;
+        [DataMember] public string Tag;
+    }
+
+    [DataContract]
+    public class StreamDiagnosticsCollectionData
+    {
+        [DataMember] public ushort PID;
+        [DataMember] public List<StreamDiagnosticsData> Diagnostics;
+    }
+
+    [DataContract]
+    public class StreamFileData
+    {
+        [DataMember] public string Name;
+        [DataMember] public long Size;
+        [DataMember] public double Length;
+        [DataMember] public string InterleavedFileName;
+        [DataMember] public List<StreamData> Streams;
+        [DataMember] public List<StreamDiagnosticsCollectionData> Diagnostics;
+    }
+
+    [DataContract]
+    public class StreamClipFileData
+    {
+        [DataMember] public string Name;
+        [DataMember] public List<StreamData> Streams;
+        [DataMember] public string FileType;
+    }
+
+    [DataContract]
+    public class StreamClipData
+    {
+        [DataMember] public string Name;
+        [DataMember] public string StreamFileName;
+        [DataMember] public string StreamClipFileName;
+        [DataMember] public int AngleIndex;
+        [DataMember] public double TimeIn;
+        [DataMember] public double TimeOut;
+        [DataMember] public double RelativeTimeIn;
+        [DataMember] public double RelativeTimeOut;
+        [DataMember] public double Length;
+        [DataMember] public double RelativeLength;
+        [DataMember] public ulong FileSize;
+        [DataMember] public ulong InterleavedFileSize;
+        [DataMember] public ulong PayloadBytes;
+        [DataMember] public ulong PacketCount;
+        [DataMember] public double PacketSeconds;
+        [DataMember] public List<double> Chapters;
+    }
+
+    [DataContract]
+    public class AngleClipEntryData
+    {
+        [DataMember] public double RelativeStart;
+        [DataMember] public string ClipName;
+    }
+
+    [DataContract]
+    public class AngleClipData
+    {
+        [DataMember] public int AngleIndex;
+        [DataMember] public List<AngleClipEntryData> Clips;
+    }
+
+    [DataContract]
+    public class AngleStreamData
+    {
+        [DataMember] public int AngleIndex;
+        [DataMember] public List<StreamData> Streams;
+    }
+
+    [DataContract]
+    public class PlaylistData
+    {
+        [DataMember] public string Name;
+        [DataMember] public bool HasHiddenTracks;
+        [DataMember] public bool HasLoops;
+        [DataMember] public bool IsCustom;
+        [DataMember] public bool MVCBaseViewR;
+        [DataMember] public int AngleCount;
+        [DataMember] public List<double> Chapters;
+        [DataMember] public List<StreamClipData> StreamClips;
+        [DataMember] public List<AngleClipData> AngleClips;
+        [DataMember] public List<AngleStreamData> AngleStreams;
+        [DataMember] public List<StreamData> Streams;
+        [DataMember] public List<StreamData> PlaylistStreams;
+        [DataMember] public List<StreamData> SortedStreams;
+        [DataMember] public List<StreamData> VideoStreams;
+        [DataMember] public List<StreamData> AudioStreams;
+        [DataMember] public List<StreamData> TextStreams;
+        [DataMember] public List<StreamData> GraphicsStreams;
+    }
+
+    [DataContract]
+    public class InterleavedFileData
+    {
+        [DataMember] public string Name;
+    }
+
+    [DataContract]
+    public class ScanFileExceptionData
+    {
+        [DataMember] public string FileName;
+        [DataMember] public string Message;
+        [DataMember] public string StackTrace;
+    }
+
+    [DataContract]
+    public class ScanResultData
+    {
+        [DataMember] public string ScanExceptionMessage;
+        [DataMember] public string ScanExceptionStack;
+        [DataMember] public List<ScanFileExceptionData> FileExceptions;
+    }
+
+    [DataContract]
+    public class BDROMData
+    {
+        [DataMember] public string VolumeLabel;
+        [DataMember] public string DiscTitle;
+        [DataMember] public ulong Size;
+        [DataMember] public bool IsBDPlus;
+        [DataMember] public bool IsBDJava;
+        [DataMember] public bool IsDBOX;
+        [DataMember] public bool IsPSP;
+        [DataMember] public bool Is3D;
+        [DataMember] public bool Is50Hz;
+        [DataMember] public bool IsUHD;
+        [DataMember] public List<StreamFileData> StreamFiles;
+        [DataMember] public List<StreamClipFileData> StreamClipFiles;
+        [DataMember] public List<InterleavedFileData> InterleavedFiles;
+        [DataMember] public List<PlaylistData> Playlists;
+    }
+
+    [DataContract]
+    public class BDInfoReportData
+    {
+        [DataMember] public string Version;
+        [DataMember] public DateTime CreatedUtc;
+        [DataMember] public string SourcePath;
+        [DataMember] public BDROMData Disc;
+        [DataMember] public ScanResultData ScanResult;
+    }
+}

--- a/BDInfo/Report/ReportModels.cs
+++ b/BDInfo/Report/ReportModels.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.Serialization;
 using BDInfo;
 
@@ -41,7 +42,35 @@ namespace BDInfo.Reporting
         [DataMember] public bool IsInterlaced;
         [DataMember] public int FrameRateEnumerator;
         [DataMember] public int FrameRateDenominator;
-        [DataMember] public TSAspectRatio AspectRatio;
+        [IgnoreDataMember]
+        public TSAspectRatio AspectRatio { get; set; }
+
+        [DataMember(Name = "AspectRatio")]
+        public string AspectRatioValue
+        {
+            get => ((int)AspectRatio).ToString(CultureInfo.InvariantCulture);
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    AspectRatio = TSAspectRatio.Unknown;
+                    return;
+                }
+
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numericValue))
+                {
+                    AspectRatio = (TSAspectRatio)numericValue;
+                }
+                else if (Enum.TryParse(value, true, out TSAspectRatio parsedValue))
+                {
+                    AspectRatio = parsedValue;
+                }
+                else
+                {
+                    AspectRatio = TSAspectRatio.Unknown;
+                }
+            }
+        }
         [DataMember] public TSVideoFormat VideoFormat;
         [DataMember] public TSFrameRate FrameRate;
         [DataMember] public string EncodingProfile;

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -318,10 +318,10 @@ namespace BDInfo.Reporting
                     }
 
                     playlist.SortedStreams = CreateStreamList(playlistData.SortedStreams);
-                    playlist.VideoStreams = CreateStreamList(playlistData.VideoStreams);
-                    playlist.AudioStreams = CreateStreamList(playlistData.AudioStreams);
-                    playlist.TextStreams = CreateStreamList(playlistData.TextStreams);
-                    playlist.GraphicsStreams = CreateStreamList(playlistData.GraphicsStreams);
+                    playlist.VideoStreams = CreateStreamList<TSVideoStream>(playlistData.VideoStreams);
+                    playlist.AudioStreams = CreateStreamList<TSAudioStream>(playlistData.AudioStreams);
+                    playlist.TextStreams = CreateStreamList<TSTextStream>(playlistData.TextStreams);
+                    playlist.GraphicsStreams = CreateStreamList<TSGraphicsStream>(playlistData.GraphicsStreams);
 
                     bdrom.PlaylistFiles[playlist.Name] = playlist;
                 }
@@ -872,6 +872,27 @@ namespace BDInfo.Reporting
                     }
                 }
             }
+        }
+
+        private static List<TStream> CreateStreamList<TStream>(List<StreamData> data) where TStream : TSStream
+        {
+            var list = new List<TStream>();
+            if (data == null)
+            {
+                return list;
+            }
+
+            foreach (var streamData in data)
+            {
+                var stream = CreateStream(streamData);
+                if (stream is TStream typed)
+                {
+                    list.Add(typed);
+                }
+            }
+
+            LinkAudioCoreStreams(list.Cast<TSStream>(), data);
+            return list;
         }
 
         private static List<TSStream> CreateStreamList(List<StreamData> data)

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -1,0 +1,950 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Xml;
+using BDInfo;
+
+namespace BDInfo.Reporting
+{
+    public static class BDInfoReportSerializer
+    {
+        private static readonly DataContractSerializer Serializer = new DataContractSerializer(typeof(BDInfoReportData));
+
+        public static void Save(string path, BDROM bdrom, IEnumerable<TSPlaylistFile> playlists, ScanBDROMResult scanResult)
+        {
+            if (bdrom == null)
+            {
+                throw new ArgumentNullException(nameof(bdrom));
+            }
+
+            if (playlists == null)
+            {
+                throw new ArgumentNullException(nameof(playlists));
+            }
+
+            var playlistList = playlists.ToList();
+            var report = new BDInfoReportData
+            {
+                CreatedUtc = DateTime.UtcNow,
+                Version = typeof(BDInfoReportSerializer).Assembly.GetName().Version?.ToString(),
+                SourcePath = GetSourcePath(bdrom),
+                Disc = BuildDiscData(bdrom, playlistList),
+                ScanResult = ConvertScanResult(scanResult)
+            };
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
+
+            using (var stream = File.Create(path))
+            using (var writer = XmlWriter.Create(stream, new XmlWriterSettings { Indent = true }))
+            {
+                Serializer.WriteObject(writer, report);
+            }
+        }
+
+        public static BDInfoReportData Load(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Path cannot be empty.", nameof(path));
+            }
+
+            using (var stream = File.OpenRead(path))
+            using (var reader = XmlReader.Create(stream))
+            {
+                var report = (BDInfoReportData)Serializer.ReadObject(reader);
+                if (report != null)
+                {
+                    report.SourcePath = path;
+                }
+                return report;
+            }
+        }
+
+        public static BDROM CreateBDROM(BDInfoReportData report)
+        {
+            if (report?.Disc == null)
+            {
+                throw new ArgumentException("Report data is incomplete.", nameof(report));
+            }
+
+            var bdrom = new BDROM
+            {
+                VolumeLabel = report.Disc.VolumeLabel,
+                DiscTitle = report.Disc.DiscTitle,
+                Size = report.Disc.Size,
+                IsBDPlus = report.Disc.IsBDPlus,
+                IsBDJava = report.Disc.IsBDJava,
+                IsDBOX = report.Disc.IsDBOX,
+                IsPSP = report.Disc.IsPSP,
+                Is3D = report.Disc.Is3D,
+                Is50Hz = report.Disc.Is50Hz,
+                IsUHD = report.Disc.IsUHD,
+                ReportPath = report.SourcePath,
+                IsImage = false
+            };
+
+            var interleavedMap = new Dictionary<string, TSInterleavedFile>(StringComparer.OrdinalIgnoreCase);
+            if (report.Disc.InterleavedFiles != null)
+            {
+                foreach (var interleavedData in report.Disc.InterleavedFiles)
+                {
+                    if (string.IsNullOrWhiteSpace(interleavedData.Name))
+                    {
+                        continue;
+                    }
+
+                    var file = new TSInterleavedFile(interleavedData.Name);
+                    bdrom.InterleavedFiles[file.Name] = file;
+                    interleavedMap[file.Name] = file;
+                }
+            }
+
+            if (report.Disc.StreamClipFiles != null)
+            {
+                foreach (var clipFileData in report.Disc.StreamClipFiles)
+                {
+                    if (string.IsNullOrWhiteSpace(clipFileData.Name))
+                    {
+                        continue;
+                    }
+
+                    var clipFile = new TSStreamClipFile(clipFileData.Name)
+                    {
+                        FileType = clipFileData.FileType,
+                        IsValid = true
+                    };
+
+                    clipFile.Streams.Clear();
+                    if (clipFileData.Streams != null)
+                    {
+                        foreach (var streamData in clipFileData.Streams)
+                        {
+                            var stream = CreateStream(streamData);
+                            clipFile.Streams[stream.PID] = stream;
+                        }
+                        LinkAudioCoreStreams(clipFile.Streams.Values, clipFileData.Streams);
+                    }
+
+                    bdrom.StreamClipFiles[clipFile.Name] = clipFile;
+                }
+            }
+
+            if (report.Disc.StreamFiles != null)
+            {
+                foreach (var streamFileData in report.Disc.StreamFiles)
+                {
+                    if (string.IsNullOrWhiteSpace(streamFileData.Name))
+                    {
+                        continue;
+                    }
+
+                    var streamFile = new TSStreamFile(streamFileData.Name, streamFileData.Size, streamFileData.Length);
+                    if (!string.IsNullOrWhiteSpace(streamFileData.InterleavedFileName) &&
+                        interleavedMap.TryGetValue(streamFileData.InterleavedFileName.ToUpperInvariant(), out var interleaved))
+                    {
+                        streamFile.InterleavedFile = interleaved;
+                    }
+
+                    streamFile.Streams.Clear();
+                    if (streamFileData.Streams != null)
+                    {
+                        foreach (var streamData in streamFileData.Streams)
+                        {
+                            var stream = CreateStream(streamData);
+                            streamFile.Streams[stream.PID] = stream;
+                        }
+                        LinkAudioCoreStreams(streamFile.Streams.Values, streamFileData.Streams);
+                    }
+
+                    streamFile.StreamDiagnostics.Clear();
+                    if (streamFileData.Diagnostics != null)
+                    {
+                        foreach (var diagCollection in streamFileData.Diagnostics)
+                        {
+                            if (diagCollection?.Diagnostics == null)
+                            {
+                                continue;
+                            }
+
+                            var diagList = new List<TSStreamDiagnostics>();
+                            foreach (var diag in diagCollection.Diagnostics)
+                            {
+                                if (diag == null)
+                                {
+                                    continue;
+                                }
+
+                                diagList.Add(new TSStreamDiagnostics
+                                {
+                                    Marker = diag.Marker,
+                                    Interval = diag.Interval,
+                                    Bytes = diag.Bytes,
+                                    Packets = diag.Packets,
+                                    Tag = diag.Tag
+                                });
+                            }
+                            streamFile.StreamDiagnostics[diagCollection.PID] = diagList;
+                        }
+                    }
+
+                    bdrom.StreamFiles[streamFile.Name] = streamFile;
+                }
+            }
+
+            if (report.Disc.Playlists != null)
+            {
+                foreach (var playlistData in report.Disc.Playlists)
+                {
+                    if (string.IsNullOrWhiteSpace(playlistData.Name))
+                    {
+                        continue;
+                    }
+
+                    var playlist = new TSPlaylistFile(bdrom, playlistData.Name)
+                    {
+                        HasHiddenTracks = playlistData.HasHiddenTracks,
+                        HasLoops = playlistData.HasLoops,
+                        IsCustom = playlistData.IsCustom,
+                        MVCBaseViewR = playlistData.MVCBaseViewR,
+                        AngleCount = playlistData.AngleCount,
+                        IsInitialized = true
+                    };
+
+                    playlist.Chapters.Clear();
+                    if (playlistData.Chapters != null)
+                    {
+                        playlist.Chapters.AddRange(playlistData.Chapters);
+                    }
+
+                    var clipLookup = new Dictionary<string, TSStreamClip>(StringComparer.OrdinalIgnoreCase);
+                    playlist.StreamClips.Clear();
+                    if (playlistData.StreamClips != null)
+                    {
+                        foreach (var clipData in playlistData.StreamClips)
+                        {
+                            var streamFile = ResolveStreamFile(bdrom, clipData.StreamFileName);
+                            var clipFile = ResolveStreamClipFile(bdrom, clipData.StreamClipFileName);
+                            var clip = new TSStreamClip(streamFile, clipFile)
+                            {
+                                Name = clipData.Name,
+                                AngleIndex = clipData.AngleIndex,
+                                TimeIn = clipData.TimeIn,
+                                TimeOut = clipData.TimeOut,
+                                RelativeTimeIn = clipData.RelativeTimeIn,
+                                RelativeTimeOut = clipData.RelativeTimeOut,
+                                Length = clipData.Length,
+                                RelativeLength = clipData.RelativeLength,
+                                FileSize = clipData.FileSize,
+                                InterleavedFileSize = clipData.InterleavedFileSize,
+                                PayloadBytes = clipData.PayloadBytes,
+                                PacketCount = clipData.PacketCount,
+                                PacketSeconds = clipData.PacketSeconds
+                            };
+
+                            if (clipData.Chapters != null)
+                            {
+                                clip.Chapters.AddRange(clipData.Chapters);
+                            }
+
+                            playlist.StreamClips.Add(clip);
+                            if (!string.IsNullOrWhiteSpace(clip.Name))
+                            {
+                                clipLookup[clip.Name] = clip;
+                            }
+                        }
+                    }
+
+                    playlist.AngleClips.Clear();
+                    if (playlistData.AngleClips != null)
+                    {
+                        foreach (var angleClipData in playlistData.AngleClips)
+                        {
+                            var angleClips = new Dictionary<double, TSStreamClip>();
+                            if (angleClipData?.Clips != null)
+                            {
+                                foreach (var entry in angleClipData.Clips)
+                                {
+                                    if (clipLookup.TryGetValue(entry.ClipName ?? string.Empty, out var clip))
+                                    {
+                                        angleClips[entry.RelativeStart] = clip;
+                                    }
+                                }
+                            }
+                            playlist.AngleClips.Add(angleClips);
+                        }
+                    }
+
+                    playlist.AngleStreams.Clear();
+                    if (playlistData.AngleStreams != null)
+                    {
+                        foreach (var angleStreamData in playlistData.AngleStreams)
+                        {
+                            var angleStreams = new Dictionary<ushort, TSStream>();
+                            if (angleStreamData?.Streams != null)
+                            {
+                                foreach (var streamData in angleStreamData.Streams)
+                                {
+                                    var stream = CreateStream(streamData);
+                                    angleStreams[stream.PID] = stream;
+                                }
+                                LinkAudioCoreStreams(angleStreams.Values, angleStreamData.Streams);
+                            }
+                            playlist.AngleStreams.Add(angleStreams);
+                        }
+                    }
+
+                    playlist.Streams.Clear();
+                    if (playlistData.Streams != null)
+                    {
+                        foreach (var streamData in playlistData.Streams)
+                        {
+                            var stream = CreateStream(streamData);
+                            playlist.Streams[stream.PID] = stream;
+                        }
+                        LinkAudioCoreStreams(playlist.Streams.Values, playlistData.Streams);
+                    }
+
+                    playlist.PlaylistStreams.Clear();
+                    if (playlistData.PlaylistStreams != null)
+                    {
+                        foreach (var streamData in playlistData.PlaylistStreams)
+                        {
+                            var stream = CreateStream(streamData);
+                            playlist.PlaylistStreams[stream.PID] = stream;
+                        }
+                        LinkAudioCoreStreams(playlist.PlaylistStreams.Values, playlistData.PlaylistStreams);
+                    }
+
+                    playlist.SortedStreams = CreateStreamList(playlistData.SortedStreams);
+                    playlist.VideoStreams = CreateStreamList(playlistData.VideoStreams);
+                    playlist.AudioStreams = CreateStreamList(playlistData.AudioStreams);
+                    playlist.TextStreams = CreateStreamList(playlistData.TextStreams);
+                    playlist.GraphicsStreams = CreateStreamList(playlistData.GraphicsStreams);
+
+                    bdrom.PlaylistFiles[playlist.Name] = playlist;
+                }
+            }
+
+            return bdrom;
+        }
+
+        public static ScanBDROMResult CreateScanResult(ScanResultData data)
+        {
+            var result = new ScanBDROMResult();
+            if (data == null)
+            {
+                result.ScanException = null;
+                return result;
+            }
+
+            if (!string.IsNullOrWhiteSpace(data.ScanExceptionMessage))
+            {
+                var message = data.ScanExceptionMessage;
+                if (!string.IsNullOrWhiteSpace(data.ScanExceptionStack))
+                {
+                    message += Environment.NewLine + data.ScanExceptionStack;
+                }
+                result.ScanException = new Exception(message);
+            }
+            else
+            {
+                result.ScanException = null;
+            }
+
+            result.FileExceptions.Clear();
+            if (data.FileExceptions != null)
+            {
+                foreach (var fileException in data.FileExceptions)
+                {
+                    var message = fileException.Message ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(fileException.StackTrace))
+                    {
+                        message += Environment.NewLine + fileException.StackTrace;
+                    }
+                    result.FileExceptions[fileException.FileName ?? string.Empty] = new Exception(message);
+                }
+            }
+
+            return result;
+        }
+
+        private static string GetSourcePath(BDROM bdrom)
+        {
+            if (!string.IsNullOrWhiteSpace(bdrom.ReportPath))
+            {
+                return bdrom.ReportPath;
+            }
+
+            if (bdrom.IsImage && bdrom.IoStream != null)
+            {
+                return bdrom.IoStream.Name;
+            }
+
+            if (bdrom.DirectoryBDMV != null)
+            {
+                return bdrom.DirectoryBDMV.FullName;
+            }
+
+            if (bdrom.DirectoryRoot != null)
+            {
+                return bdrom.DirectoryRoot.FullName;
+            }
+
+            return bdrom.VolumeLabel;
+        }
+
+        private static BDROMData BuildDiscData(BDROM bdrom, List<TSPlaylistFile> playlists)
+        {
+            var disc = new BDROMData
+            {
+                VolumeLabel = bdrom.VolumeLabel,
+                DiscTitle = bdrom.DiscTitle,
+                Size = bdrom.Size,
+                IsBDPlus = bdrom.IsBDPlus,
+                IsBDJava = bdrom.IsBDJava,
+                IsDBOX = bdrom.IsDBOX,
+                IsPSP = bdrom.IsPSP,
+                Is3D = bdrom.Is3D,
+                Is50Hz = bdrom.Is50Hz,
+                IsUHD = bdrom.IsUHD,
+                StreamFiles = new List<StreamFileData>(),
+                StreamClipFiles = new List<StreamClipFileData>(),
+                InterleavedFiles = new List<InterleavedFileData>(),
+                Playlists = new List<PlaylistData>()
+            };
+
+            var exportedInterleaved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var interleaved in bdrom.InterleavedFiles.Values)
+            {
+                if (interleaved == null || string.IsNullOrWhiteSpace(interleaved.Name) || !exportedInterleaved.Add(interleaved.Name))
+                {
+                    continue;
+                }
+                disc.InterleavedFiles.Add(new InterleavedFileData { Name = interleaved.Name });
+            }
+
+            foreach (var streamFile in bdrom.StreamFiles.Values)
+            {
+                if (streamFile == null)
+                {
+                    continue;
+                }
+
+                var streamFileData = new StreamFileData
+                {
+                    Name = streamFile.Name,
+                    Size = streamFile.Size,
+                    Length = streamFile.Length,
+                    InterleavedFileName = streamFile.InterleavedFile?.Name,
+                    Streams = ConvertStreams(streamFile.Streams?.Values),
+                    Diagnostics = ConvertDiagnostics(streamFile.StreamDiagnostics)
+                };
+
+                disc.StreamFiles.Add(streamFileData);
+            }
+
+            foreach (var clipFile in bdrom.StreamClipFiles.Values)
+            {
+                if (clipFile == null)
+                {
+                    continue;
+                }
+
+                var clipData = new StreamClipFileData
+                {
+                    Name = clipFile.Name,
+                    FileType = clipFile.FileType,
+                    Streams = ConvertStreams(clipFile.Streams?.Values)
+                };
+
+                disc.StreamClipFiles.Add(clipData);
+            }
+
+            foreach (var playlist in playlists)
+            {
+                if (playlist == null)
+                {
+                    continue;
+                }
+
+                disc.Playlists.Add(ConvertPlaylist(playlist));
+            }
+
+            return disc;
+        }
+
+        private static List<StreamDiagnosticsCollectionData> ConvertDiagnostics(Dictionary<ushort, List<TSStreamDiagnostics>> diagnostics)
+        {
+            if (diagnostics == null || diagnostics.Count == 0)
+            {
+                return new List<StreamDiagnosticsCollectionData>();
+            }
+
+            var list = new List<StreamDiagnosticsCollectionData>();
+            foreach (var kvp in diagnostics)
+            {
+                var collection = new StreamDiagnosticsCollectionData
+                {
+                    PID = kvp.Key,
+                    Diagnostics = new List<StreamDiagnosticsData>()
+                };
+
+                if (kvp.Value != null)
+                {
+                    foreach (var diag in kvp.Value)
+                    {
+                        if (diag == null)
+                        {
+                            continue;
+                        }
+
+                        collection.Diagnostics.Add(new StreamDiagnosticsData
+                        {
+                            Marker = diag.Marker,
+                            Interval = diag.Interval,
+                            Bytes = diag.Bytes,
+                            Packets = diag.Packets,
+                            Tag = diag.Tag
+                        });
+                    }
+                }
+
+                list.Add(collection);
+            }
+
+            return list;
+        }
+
+        private static PlaylistData ConvertPlaylist(TSPlaylistFile playlist)
+        {
+            var data = new PlaylistData
+            {
+                Name = playlist.Name,
+                HasHiddenTracks = playlist.HasHiddenTracks,
+                HasLoops = playlist.HasLoops,
+                IsCustom = playlist.IsCustom,
+                MVCBaseViewR = playlist.MVCBaseViewR,
+                AngleCount = playlist.AngleCount,
+                Chapters = playlist.Chapters != null ? new List<double>(playlist.Chapters) : new List<double>(),
+                StreamClips = ConvertStreamClips(playlist.StreamClips),
+                AngleClips = ConvertAngleClips(playlist.AngleClips),
+                AngleStreams = ConvertAngleStreams(playlist.AngleStreams),
+                Streams = ConvertStreams(playlist.Streams?.Values),
+                PlaylistStreams = ConvertStreams(playlist.PlaylistStreams?.Values),
+                SortedStreams = ConvertStreams(playlist.SortedStreams),
+                VideoStreams = ConvertStreams(playlist.VideoStreams),
+                AudioStreams = ConvertStreams(playlist.AudioStreams),
+                TextStreams = ConvertStreams(playlist.TextStreams),
+                GraphicsStreams = ConvertStreams(playlist.GraphicsStreams)
+            };
+
+            return data;
+        }
+
+        private static List<StreamClipData> ConvertStreamClips(IEnumerable<TSStreamClip> clips)
+        {
+            var list = new List<StreamClipData>();
+            if (clips == null)
+            {
+                return list;
+            }
+
+            foreach (var clip in clips)
+            {
+                if (clip == null)
+                {
+                    continue;
+                }
+
+                var clipData = new StreamClipData
+                {
+                    Name = clip.Name,
+                    StreamFileName = clip.StreamFile?.Name,
+                    StreamClipFileName = clip.StreamClipFile?.Name,
+                    AngleIndex = clip.AngleIndex,
+                    TimeIn = clip.TimeIn,
+                    TimeOut = clip.TimeOut,
+                    RelativeTimeIn = clip.RelativeTimeIn,
+                    RelativeTimeOut = clip.RelativeTimeOut,
+                    Length = clip.Length,
+                    RelativeLength = clip.RelativeLength,
+                    FileSize = clip.FileSize,
+                    InterleavedFileSize = clip.InterleavedFileSize,
+                    PayloadBytes = clip.PayloadBytes,
+                    PacketCount = clip.PacketCount,
+                    PacketSeconds = clip.PacketSeconds,
+                    Chapters = clip.Chapters != null ? new List<double>(clip.Chapters) : new List<double>()
+                };
+
+                list.Add(clipData);
+            }
+
+            return list;
+        }
+
+        private static List<AngleClipData> ConvertAngleClips(IEnumerable<Dictionary<double, TSStreamClip>> angleClips)
+        {
+            var list = new List<AngleClipData>();
+            if (angleClips == null)
+            {
+                return list;
+            }
+
+            var index = 0;
+            foreach (var dictionary in angleClips)
+            {
+                var angleData = new AngleClipData
+                {
+                    AngleIndex = index++,
+                    Clips = new List<AngleClipEntryData>()
+                };
+
+                if (dictionary != null)
+                {
+                    foreach (var kvp in dictionary)
+                    {
+                        angleData.Clips.Add(new AngleClipEntryData
+                        {
+                            RelativeStart = kvp.Key,
+                            ClipName = kvp.Value?.Name
+                        });
+                    }
+                }
+
+                list.Add(angleData);
+            }
+
+            return list;
+        }
+
+        private static List<AngleStreamData> ConvertAngleStreams(IEnumerable<Dictionary<ushort, TSStream>> angleStreams)
+        {
+            var list = new List<AngleStreamData>();
+            if (angleStreams == null)
+            {
+                return list;
+            }
+
+            var index = 0;
+            foreach (var dictionary in angleStreams)
+            {
+                var angleData = new AngleStreamData
+                {
+                    AngleIndex = index++,
+                    Streams = ConvertStreams(dictionary?.Values)
+                };
+                list.Add(angleData);
+            }
+
+            return list;
+        }
+
+        private static List<StreamData> ConvertStreams(IEnumerable<TSStream> streams)
+        {
+            var list = new List<StreamData>();
+            if (streams == null)
+            {
+                return list;
+            }
+
+            foreach (var stream in streams)
+            {
+                if (stream == null)
+                {
+                    continue;
+                }
+                list.Add(CreateStreamData(stream));
+            }
+
+            return list;
+        }
+
+        private static StreamData CreateStreamData(TSStream stream)
+        {
+            StreamData data;
+            if (stream is TSVideoStream video)
+            {
+                data = new VideoStreamData
+                {
+                    VideoFormat = video.VideoFormat,
+                    FrameRate = video.FrameRate,
+                    AspectRatio = video.AspectRatio,
+                    Width = video.Width,
+                    Height = video.Height,
+                    IsInterlaced = video.IsInterlaced,
+                    FrameRateEnumerator = video.FrameRateEnumerator,
+                    FrameRateDenominator = video.FrameRateDenominator,
+                    EncodingProfile = video.EncodingProfile
+                };
+            }
+            else if (stream is TSAudioStream audio)
+            {
+                data = new AudioStreamData
+                {
+                    SampleRate = audio.SampleRate,
+                    ChannelCount = audio.ChannelCount,
+                    BitDepth = audio.BitDepth,
+                    LFE = audio.LFE,
+                    DialNorm = audio.DialNorm,
+                    HasExtensions = audio.HasExtensions,
+                    AudioMode = audio.AudioMode,
+                    ChannelLayout = audio.ChannelLayout,
+                    ExtendedData = audio.ExtendedData as string,
+                    CoreStreamPID = audio.CoreStream?.PID
+                };
+            }
+            else if (stream is TSGraphicsStream graphics)
+            {
+                data = new GraphicsStreamData
+                {
+                    Width = graphics.Width,
+                    Height = graphics.Height,
+                    Captions = graphics.Captions,
+                    ForcedCaptions = graphics.ForcedCaptions
+                };
+            }
+            else if (stream is TSTextStream)
+            {
+                data = new TextStreamData();
+            }
+            else
+            {
+                data = new StreamData();
+            }
+
+            data.PID = stream.PID;
+            data.StreamType = stream.StreamType;
+            data.IsVBR = stream.IsVBR;
+            data.BitRate = stream.BitRate;
+            data.ActiveBitRate = stream.ActiveBitRate;
+            data.IsInitialized = stream.IsInitialized;
+            data.LanguageCode = stream.LanguageCode;
+            data.LanguageName = stream.LanguageName;
+            data.IsHidden = stream.IsHidden;
+            data.PayloadBytes = stream.PayloadBytes;
+            data.PacketCount = stream.PacketCount;
+            data.PacketSeconds = stream.PacketSeconds;
+            data.AngleIndex = stream.AngleIndex;
+            data.BaseView = stream.BaseView;
+
+            if (!(stream is TSAudioStream) && stream is TSVideoStream videoStream)
+            {
+                data.ExtendedData = videoStream.ExtendedData as string;
+            }
+
+            return data;
+        }
+
+        private static TSStream CreateStream(StreamData data)
+        {
+            if (data == null)
+            {
+                return null;
+            }
+
+            TSStream stream;
+            switch (data.StreamType)
+            {
+                case TSStreamType.MPEG1_VIDEO:
+                case TSStreamType.MPEG2_VIDEO:
+                case TSStreamType.AVC_VIDEO:
+                case TSStreamType.MVC_VIDEO:
+                case TSStreamType.VC1_VIDEO:
+                case TSStreamType.HEVC_VIDEO:
+                {
+                    var video = new TSVideoStream
+                    {
+                        VideoFormat = data.VideoFormat,
+                        FrameRate = data.FrameRate,
+                        AspectRatio = data.AspectRatio,
+                        EncodingProfile = data.EncodingProfile
+                    };
+                    video.Width = data.Width;
+                    video.Height = data.Height;
+                    video.IsInterlaced = data.IsInterlaced;
+                    video.FrameRateEnumerator = data.FrameRateEnumerator;
+                    video.FrameRateDenominator = data.FrameRateDenominator;
+                    stream = video;
+                    break;
+                }
+
+                case TSStreamType.MPEG1_AUDIO:
+                case TSStreamType.MPEG2_AUDIO:
+                case TSStreamType.MPEG2_AAC_AUDIO:
+                case TSStreamType.MPEG4_AAC_AUDIO:
+                case TSStreamType.LPCM_AUDIO:
+                case TSStreamType.AC3_AUDIO:
+                case TSStreamType.AC3_PLUS_AUDIO:
+                case TSStreamType.AC3_PLUS_SECONDARY_AUDIO:
+                case TSStreamType.AC3_TRUE_HD_AUDIO:
+                case TSStreamType.DTS_AUDIO:
+                case TSStreamType.DTS_HD_AUDIO:
+                case TSStreamType.DTS_HD_SECONDARY_AUDIO:
+                case TSStreamType.DTS_HD_MASTER_AUDIO:
+                {
+                    var audio = new TSAudioStream
+                    {
+                        SampleRate = data.SampleRate,
+                        ChannelCount = data.ChannelCount,
+                        BitDepth = data.BitDepth,
+                        LFE = data.LFE,
+                        DialNorm = data.DialNorm,
+                        HasExtensions = data.HasExtensions,
+                        AudioMode = data.AudioMode,
+                        ChannelLayout = data.ChannelLayout,
+                        ExtendedData = data.ExtendedData
+                    };
+                    stream = audio;
+                    break;
+                }
+
+                case TSStreamType.PRESENTATION_GRAPHICS:
+                case TSStreamType.INTERACTIVE_GRAPHICS:
+                {
+                    var graphics = new TSGraphicsStream
+                    {
+                        Width = data.Width,
+                        Height = data.Height,
+                        Captions = data.Captions,
+                        ForcedCaptions = data.ForcedCaptions
+                    };
+                    stream = graphics;
+                    break;
+                }
+
+                case TSStreamType.SUBTITLE:
+                {
+                    stream = new TSTextStream();
+                    break;
+                }
+
+                default:
+                {
+                    stream = new TSTextStream();
+                    break;
+                }
+            }
+
+            stream.PID = data.PID;
+            stream.StreamType = data.StreamType;
+            stream.IsVBR = data.IsVBR;
+            stream.BitRate = data.BitRate;
+            stream.ActiveBitRate = data.ActiveBitRate;
+            stream.IsInitialized = data.IsInitialized;
+            stream.LanguageCode = data.LanguageCode;
+            stream.LanguageName = data.LanguageName;
+            stream.IsHidden = data.IsHidden;
+            stream.PayloadBytes = data.PayloadBytes;
+            stream.PacketCount = data.PacketCount;
+            stream.PacketSeconds = data.PacketSeconds;
+            stream.AngleIndex = data.AngleIndex;
+            stream.BaseView = data.BaseView;
+
+            return stream;
+        }
+
+        private static void LinkAudioCoreStreams(IEnumerable<TSStream> streams, IEnumerable<StreamData> data)
+        {
+            if (streams == null || data == null)
+            {
+                return;
+            }
+
+            var audioMap = new Dictionary<ushort, TSAudioStream>();
+            foreach (var stream in streams)
+            {
+                if (stream is TSAudioStream audio)
+                {
+                    audioMap[stream.PID] = audio;
+                }
+            }
+
+            foreach (var streamData in data)
+            {
+                if (streamData is AudioStreamData audioData && audioData.CoreStreamPID.HasValue)
+                {
+                    if (audioMap.TryGetValue(streamData.PID, out var audio) &&
+                        audioMap.TryGetValue(audioData.CoreStreamPID.Value, out var core))
+                    {
+                        audio.CoreStream = core;
+                    }
+                }
+            }
+        }
+
+        private static List<TSStream> CreateStreamList(List<StreamData> data)
+        {
+            var list = new List<TSStream>();
+            if (data == null)
+            {
+                return list;
+            }
+
+            foreach (var streamData in data)
+            {
+                var stream = CreateStream(streamData);
+                if (stream != null)
+                {
+                    list.Add(stream);
+                }
+            }
+
+            LinkAudioCoreStreams(list, data);
+            return list;
+        }
+
+        private static TSStreamFile ResolveStreamFile(BDROM bdrom, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return null;
+            }
+
+            var key = name.ToUpperInvariant();
+            return bdrom.StreamFiles.ContainsKey(key) ? bdrom.StreamFiles[key] : null;
+        }
+
+        private static TSStreamClipFile ResolveStreamClipFile(BDROM bdrom, string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return null;
+            }
+
+            var key = name.ToUpperInvariant();
+            return bdrom.StreamClipFiles.ContainsKey(key) ? bdrom.StreamClipFiles[key] : null;
+        }
+
+        private static ScanResultData ConvertScanResult(ScanBDROMResult result)
+        {
+            if (result == null)
+            {
+                return null;
+            }
+
+            var data = new ScanResultData
+            {
+                ScanExceptionMessage = result.ScanException?.Message,
+                ScanExceptionStack = result.ScanException?.StackTrace,
+                FileExceptions = new List<ScanFileExceptionData>()
+            };
+
+            if (result.FileExceptions != null)
+            {
+                foreach (var kvp in result.FileExceptions)
+                {
+                    data.FileExceptions.Add(new ScanFileExceptionData
+                    {
+                        FileName = kvp.Key,
+                        Message = kvp.Value?.Message,
+                        StackTrace = kvp.Value?.StackTrace
+                    });
+                }
+            }
+
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce data contract models and a serializer to persist BDInfo scan data for reuse
- add an export button to the report window and disable scan/rescan actions when working from saved reports
- support loading `.bdinfo` files through the main UI, rebuilding in-memory structures for full chart/report functionality

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0e26665dc83249f13ee648df7c84c