### PR TITLE
Fix HDR10+ flag persistence between scans

### DIFF
--- a/BDInfo/BDROM/TSCodecHEVC.cs
+++ b/BDInfo/BDROM/TSCodecHEVC.cs
@@ -469,6 +469,8 @@ namespace BDInfo
 
             ExtendedData = (ExtendedDataSet)stream.ExtendedData;
 
+            IsHdr10Plus = ExtendedData.IsHdr10Plus;
+
             VideoParamSets = ExtendedData.VideoParamSets;
             VUIParameterSets = ExtendedData.VUIParameterSets;
             SeqParameterSets = ExtendedData.SeqParameterSets;


### PR DESCRIPTION
## Summary
- reset the static HDR10+ detection flag from the stored stream metadata before scanning
- ensure subsequent discs without HDR10+ are reported correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f11f266f3483249de15c1204e06b4e