### PR TITLE
Add support for compressed bdinfo reports

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -67,6 +67,8 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -42,6 +42,7 @@ namespace BDInfo
             public bool ReportFormatsSpecified;
             public List<string> PlaylistNames { get; } = new List<string>();
             public HashSet<ReportFormat> ReportFormats { get; } = new HashSet<ReportFormat> { ReportFormat.Text };
+            public bool CompressReports;
         }
 
         public static bool TryHandle(string[] args)
@@ -155,6 +156,12 @@ namespace BDInfo
                     {
                         options.ChartFormat = value;
                     }
+                    continue;
+                }
+
+                if (IsOption(arg, "-z", "--compress"))
+                {
+                    options.CompressReports = true;
                     continue;
                 }
 
@@ -428,7 +435,13 @@ namespace BDInfo
                     options.ReportFormats.Add(ReportFormat.Text);
                 }
 
-                List<string> reportPaths = GenerateReports(bdrom, selectedPlaylists, scanResult, reportDestination, options.ReportFormats);
+                List<string> reportPaths = GenerateReports(
+                    bdrom,
+                    selectedPlaylists,
+                    scanResult,
+                    reportDestination,
+                    options.ReportFormats,
+                    options.CompressReports);
                 foreach (string path in reportPaths)
                 {
                     Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Report written to: {0}", path));
@@ -1075,7 +1088,13 @@ namespace BDInfo
             }
         }
 
-        private static List<string> GenerateReports(BDROM bdrom, List<TSPlaylistFile> playlists, ScanBDROMResult scanResult, string destination, IReadOnlyCollection<ReportFormat> formats)
+        private static List<string> GenerateReports(
+            BDROM bdrom,
+            List<TSPlaylistFile> playlists,
+            ScanBDROMResult scanResult,
+            string destination,
+            IReadOnlyCollection<ReportFormat> formats,
+            bool compress)
         {
             if (formats == null || formats.Count == 0)
             {
@@ -1112,13 +1131,13 @@ namespace BDInfo
             if (formats.Contains(ReportFormat.BdinfoJson))
             {
                 string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
-                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json);
+                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json, compress);
                 writtenPaths.Add(reportPath);
             }
             else if (formats.Contains(ReportFormat.Bdinfo))
             {
                 string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
-                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml);
+                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml, compress);
                 writtenPaths.Add(reportPath);
             }
 
@@ -1228,6 +1247,7 @@ namespace BDInfo
             Console.WriteLine("  -v, --version              Print the version.");
             Console.WriteLine("  -c, --charts               Save all charts as image (select image format, default png)");
             Console.WriteLine("  -r, --report              Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.");
+            Console.WriteLine("  -z, --compress            Compress generated .bdinfo reports using ZIP.");
         }
     }
 }

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1158,7 +1158,12 @@ namespace BDInfo
 
             using (SaveFileDialog dialog = new SaveFileDialog())
             {
-                dialog.Filter = "BDInfo Report (XML) (*.bdinfo)|*.bdinfo|BDInfo Report (JSON) (*.bdinfo)|*.bdinfo|All files (*.*)|*.*";
+                dialog.Filter = string.Join("|",
+                    "BDInfo Report (XML) (*.bdinfo)", "*.bdinfo",
+                    "BDInfo Report (JSON) (*.bdinfo)", "*.bdinfo",
+                    "BDInfo Report (XML, compressed) (*.bdinfo)", "*.bdinfo",
+                    "BDInfo Report (JSON, compressed) (*.bdinfo)", "*.bdinfo",
+                    "All files (*.*)", "*.*");
                 dialog.DefaultExt = "bdinfo";
                 dialog.FileName = defaultName;
 
@@ -1166,10 +1171,17 @@ namespace BDInfo
                 {
                     try
                     {
-                        BDInfoReportFormat format = dialog.FilterIndex == 2
+                        bool compress = dialog.FilterIndex == 3 || dialog.FilterIndex == 4;
+                        BDInfoReportFormat format = dialog.FilterIndex == 2 || dialog.FilterIndex == 4
                             ? BDInfoReportFormat.Json
                             : BDInfoReportFormat.Xml;
-                        BDInfoReportSerializer.Save(dialog.FileName, ReportBDROM, ReportPlaylists, ReportScanResult, format);
+                        BDInfoReportSerializer.Save(
+                            dialog.FileName,
+                            ReportBDROM,
+                            ReportPlaylists,
+                            ReportScanResult,
+                            format,
+                            compress);
                         MessageBox.Show(this,
                             "Report exported successfully.",
                             "BDInfo",

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
@@ -31,7 +32,8 @@ namespace BDInfo.Reporting
             BDROM bdrom,
             IEnumerable<TSPlaylistFile> playlists,
             ScanBDROMResult scanResult,
-            BDInfoReportFormat format = BDInfoReportFormat.Xml)
+            BDInfoReportFormat format = BDInfoReportFormat.Xml,
+            bool compress = false)
         {
             if (bdrom == null)
             {
@@ -55,32 +57,24 @@ namespace BDInfo.Reporting
 
             Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
 
-            using (var stream = File.Create(path))
+            if (compress)
             {
-                switch (format)
+                using (var fileStream = File.Create(path))
+                using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
                 {
-                    case BDInfoReportFormat.Json:
-                        using (var writer = JsonReaderWriterFactory.CreateJsonWriter(
-                                   stream,
-                                   Encoding.UTF8,
-                                   ownsStream: false,
-                                   indent: true,
-                                   indentChars: "  "))
-                        {
-                            JsonSerializer.WriteObject(writer, report);
-                            writer.Flush();
-                        }
-
-                        stream.SetLength(stream.Position);
-                        break;
-
-                    default:
-                        using (var writer = XmlWriter.Create(stream, new XmlWriterSettings { Indent = true }))
-                        {
-                            XmlSerializer.WriteObject(writer, report);
-                        }
-
-                        break;
+                    string entryName = format == BDInfoReportFormat.Json ? "report.json" : "report.xml";
+                    var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+                    using (var entryStream = entry.Open())
+                    {
+                        WriteReport(entryStream, report, format);
+                    }
+                }
+            }
+            else
+            {
+                using (var stream = File.Create(path))
+                {
+                    WriteReport(stream, report, format);
                 }
             }
         }
@@ -93,36 +87,46 @@ namespace BDInfo.Reporting
             }
             using (var stream = File.OpenRead(path))
             {
-                var format = DetectFormat(stream);
-
-                BDInfoReportData report;
-                switch (format)
+                if (IsZipArchive(stream))
                 {
-                    case BDInfoReportFormat.Json:
-                        stream.Seek(0, SeekOrigin.Begin);
-                        using (var reader = JsonReaderWriterFactory.CreateJsonReader(stream, Encoding.UTF8, XmlDictionaryReaderQuotas.Max, null))
+                    using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
+                    {
+                        var entry = SelectReportEntry(archive);
+                        if (entry == null)
                         {
-                            report = (BDInfoReportData)JsonSerializer.ReadObject(reader);
+                            throw new SerializationException("Report archive does not contain a report entry.");
                         }
 
-                        break;
-
-                    default:
-                        stream.Seek(0, SeekOrigin.Begin);
-                        using (var reader = XmlReader.Create(stream))
+                        using (var entryStream = entry.Open())
+                        using (var buffer = new MemoryStream())
                         {
-                            report = (BDInfoReportData)XmlSerializer.ReadObject(reader);
+                            entryStream.CopyTo(buffer);
+                            buffer.Seek(0, SeekOrigin.Begin);
+
+                            var format = DetectFormat(buffer);
+                            buffer.Seek(0, SeekOrigin.Begin);
+                            var report = ReadReport(buffer, format);
+                            if (report != null)
+                            {
+                                report.SourcePath = path;
+                            }
+
+                            return report;
                         }
-
-                        break;
+                    }
                 }
-
-                if (report != null)
+                else
                 {
-                    report.SourcePath = path;
-                }
+                    var format = DetectFormat(stream);
+                    stream.Seek(0, SeekOrigin.Begin);
+                    var report = ReadReport(stream, format);
+                    if (report != null)
+                    {
+                        report.SourcePath = path;
+                    }
 
-                return report;
+                    return report;
+                }
             }
         }
 
@@ -162,6 +166,98 @@ namespace BDInfo.Reporting
             finally
             {
                 stream.Seek(originalPosition, SeekOrigin.Begin);
+            }
+        }
+
+        private static bool IsZipArchive(Stream stream)
+        {
+            if (!stream.CanSeek)
+            {
+                return false;
+            }
+
+            long originalPosition = stream.Position;
+            try
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                int first = stream.ReadByte();
+                int second = stream.ReadByte();
+                return first == 'P' && second == 'K';
+            }
+            finally
+            {
+                stream.Seek(originalPosition, SeekOrigin.Begin);
+            }
+        }
+
+        private static ZipArchiveEntry SelectReportEntry(ZipArchive archive)
+        {
+            if (archive == null)
+            {
+                return null;
+            }
+
+            var entry = archive.Entries
+                .FirstOrDefault(e => string.Equals(e.Name, "report.json", StringComparison.OrdinalIgnoreCase))
+                       ?? archive.Entries
+                .FirstOrDefault(e => string.Equals(e.Name, "report.xml", StringComparison.OrdinalIgnoreCase));
+
+            if (entry != null)
+            {
+                return entry;
+            }
+
+            return archive.Entries.FirstOrDefault(e => e.Length > 0);
+        }
+
+        private static void WriteReport(Stream stream, BDInfoReportData report, BDInfoReportFormat format)
+        {
+            switch (format)
+            {
+                case BDInfoReportFormat.Json:
+                    using (var writer = JsonReaderWriterFactory.CreateJsonWriter(
+                               stream,
+                               Encoding.UTF8,
+                               ownsStream: false,
+                               indent: true,
+                               indentChars: "  "))
+                    {
+                        JsonSerializer.WriteObject(writer, report);
+                        writer.Flush();
+                    }
+
+                    if (stream.CanSeek)
+                    {
+                        stream.SetLength(stream.Position);
+                    }
+
+                    break;
+
+                default:
+                    using (var writer = XmlWriter.Create(stream, new XmlWriterSettings { Indent = true }))
+                    {
+                        XmlSerializer.WriteObject(writer, report);
+                    }
+
+                    break;
+            }
+        }
+
+        private static BDInfoReportData ReadReport(Stream stream, BDInfoReportFormat format)
+        {
+            switch (format)
+            {
+                case BDInfoReportFormat.Json:
+                    using (var reader = JsonReaderWriterFactory.CreateJsonReader(stream, Encoding.UTF8, XmlDictionaryReaderQuotas.Max, null))
+                    {
+                        return (BDInfoReportData)JsonSerializer.ReadObject(reader);
+                    }
+
+                default:
+                    using (var reader = XmlReader.Create(stream))
+                    {
+                        return (BDInfoReportData)XmlSerializer.ReadObject(reader);
+                    }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow exporting reports from the GUI with optional ZIP compression and expand the file dialog options accordingly
- add a `--compress` CLI switch so console exports can zip the generated .bdinfo files
- detect and transparently load ZIP-compressed .bdinfo reports while adding compression references to the project

## Testing
- dotnet build BDInfo.sln *(fails: .NET Framework v4.8 reference assemblies are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f66560eb308324aa061c18ae6a7973