### PR TITLE
Fix CLI reports missing stream descriptions

### DIFF
--- a/BDInfo/BDROM/TSCodecPGS.cs
+++ b/BDInfo/BDROM/TSCodecPGS.cs
@@ -58,9 +58,8 @@ namespace BDInfo
         private static string ReadODS(TSGraphicsStream stream, TSStreamBuffer buffer)
         {
             string tag = string.Empty;
-            int temp = 0;
-            int segmentSize = buffer.ReadBits2(16, false);
-            int objectID = buffer.ReadBits2(16, false); // object ID
+            _ = buffer.ReadBits2(16, false);
+            _ = buffer.ReadBits2(16, false); // object ID
 
             if (!stream.LastFrame.Finished)
             {
@@ -81,8 +80,7 @@ namespace BDInfo
 
         private static void ReadPCS(TSGraphicsStream stream, TSStreamBuffer buffer)
         {
-            int temp = 0;
-            int segmentSize = buffer.ReadBits2(16, false);
+            _ = buffer.ReadBits2(16, false);
             if (!stream.IsInitialized)
             {
                 stream.Width = buffer.ReadBits2(16, false);
@@ -91,27 +89,27 @@ namespace BDInfo
             }
             else
             {
-                temp = buffer.ReadBits2(16, false);
-                temp = buffer.ReadBits2(16, false);
+                _ = buffer.ReadBits2(16, false);
+                _ = buffer.ReadBits2(16, false);
             }
-            
-            temp = buffer.ReadByte();
+
+            _ = buffer.ReadByte();
             int compositionNumber = buffer.ReadBits2(16, false);
             int compositionState = buffer.ReadByte(false);
-            temp = buffer.ReadBits2(16, false);
+            _ = buffer.ReadBits2(16, false);
             int numCompositionObjects = buffer.ReadByte(false);
 
-            for (int i = 0; i < numCompositionObjects; i++) 
+            for (int i = 0; i < numCompositionObjects; i++)
             {
                 int objectID = buffer.ReadBits2(16, false); // object ID
-                temp = buffer.ReadByte(false); // Window ID
+                _ = buffer.ReadByte(false); // Window ID
                 var forced = buffer.ReadByte(false); // Object Cropped Flag
-                temp = buffer.ReadBits2(16, false); // Object Horizontal Position
-                temp = buffer.ReadBits2(16, false); // Object Vertical Position
-                temp = buffer.ReadBits2(16, false); // Object Cropping Horizontal Position
-                temp = buffer.ReadBits2(16, false); // Object Cropping Vertical Position
-                temp = buffer.ReadBits2(16, false); // Object Cropping Width
-                temp = buffer.ReadBits2(16, false); // Object Cropping Height Position
+                _ = buffer.ReadBits2(16, false); // Object Horizontal Position
+                _ = buffer.ReadBits2(16, false); // Object Vertical Position
+                _ = buffer.ReadBits2(16, false); // Object Cropping Horizontal Position
+                _ = buffer.ReadBits2(16, false); // Object Cropping Vertical Position
+                _ = buffer.ReadBits2(16, false); // Object Cropping Width
+                _ = buffer.ReadBits2(16, false); // Object Cropping Height Position
 
                 stream.LastFrame = new Frame { Started = true, Forced = (forced & 0x40) == 0x40, Finished = false };
 

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1044,6 +1044,14 @@ namespace BDInfo
                             MergeAudioStream(playlistAudioStream, clipAudioStream);
                             UpdatePlaylistAudioReferences(playlist, clipAudioStream);
                         }
+                        else if (clipStream.IsVideoStream && playlistStream.IsVideoStream)
+                        {
+                            var playlistVideoStream = (TSVideoStream)playlistStream;
+                            var clipVideoStream = (TSVideoStream)clipStream;
+
+                            MergeVideoStream(playlistVideoStream, clipVideoStream);
+                            UpdatePlaylistVideoReferences(playlist, clipVideoStream);
+                        }
                     }
                 }
             }
@@ -1136,6 +1144,228 @@ namespace BDInfo
             else
             {
                 MergeAudioStream(target.CoreStream, sourceCore);
+            }
+        }
+
+        private static void MergeVideoStream(TSVideoStream target, TSVideoStream source)
+        {
+            if (target == null || source == null)
+            {
+                return;
+            }
+
+            if (source.Width > target.Width)
+            {
+                target.Width = source.Width;
+            }
+
+            if (source.Height > target.Height)
+            {
+                target.Height = source.Height;
+            }
+
+            if (source.FrameRate != TSFrameRate.Unknown)
+            {
+                target.FrameRate = source.FrameRate;
+            }
+
+            if (source.FrameRateEnumerator > 0)
+            {
+                target.FrameRateEnumerator = source.FrameRateEnumerator;
+            }
+
+            if (source.FrameRateDenominator > 0)
+            {
+                target.FrameRateDenominator = source.FrameRateDenominator;
+            }
+
+            if (source.AspectRatio != TSAspectRatio.Unknown)
+            {
+                target.AspectRatio = source.AspectRatio;
+            }
+
+            if (!string.IsNullOrEmpty(source.EncodingProfile))
+            {
+                target.EncodingProfile = source.EncodingProfile;
+            }
+
+            if (source.BitRate > target.BitRate)
+            {
+                target.BitRate = source.BitRate;
+            }
+
+            if (source.ActiveBitRate > target.ActiveBitRate)
+            {
+                target.ActiveBitRate = source.ActiveBitRate;
+            }
+
+            if (source.BaseView != null && target.BaseView == null)
+            {
+                target.BaseView = source.BaseView;
+            }
+
+            if (source.IsInitialized)
+            {
+                target.IsInitialized = true;
+            }
+
+            target.IsVBR = source.IsVBR;
+
+            MergeVideoExtendedData(target, source);
+        }
+
+        private static void MergeVideoExtendedData(TSVideoStream target, TSVideoStream source)
+        {
+            if (target == null || source == null)
+            {
+                return;
+            }
+
+            if (source.ExtendedData is TSCodecHEVC.ExtendedDataSet sourceExtended)
+            {
+                if (target.ExtendedData is TSCodecHEVC.ExtendedDataSet targetExtended)
+                {
+                    MergeHevcExtendedData(targetExtended, sourceExtended);
+                }
+                else
+                {
+                    target.ExtendedData = CloneHevcExtendedData(sourceExtended);
+                }
+            }
+            else if (source.ExtendedData != null && target.ExtendedData == null)
+            {
+                target.ExtendedData = source.ExtendedData;
+            }
+        }
+
+        private static TSCodecHEVC.ExtendedDataSet CloneHevcExtendedData(TSCodecHEVC.ExtendedDataSet source)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            var clone = new TSCodecHEVC.ExtendedDataSet
+            {
+                MasteringDisplayColorPrimaries = source.MasteringDisplayColorPrimaries,
+                MasteringDisplayLuminance = source.MasteringDisplayLuminance,
+                MaximumContentLightLevel = source.MaximumContentLightLevel,
+                MaximumFrameAverageLightLevel = source.MaximumFrameAverageLightLevel,
+                LightLevelAvailable = source.LightLevelAvailable,
+                PreferredTransferCharacteristics = source.PreferredTransferCharacteristics,
+                IsHdr10Plus = source.IsHdr10Plus
+            };
+
+            if (source.ExtendedFormatInfo != null && source.ExtendedFormatInfo.Count > 0)
+            {
+                clone.ExtendedFormatInfo.AddRange(source.ExtendedFormatInfo);
+            }
+
+            if (source.VideoParamSets != null && source.VideoParamSets.Count > 0)
+            {
+                clone.VideoParamSets.AddRange(source.VideoParamSets);
+            }
+
+            if (source.VUIParameterSets != null && source.VUIParameterSets.Count > 0)
+            {
+                clone.VUIParameterSets.AddRange(source.VUIParameterSets);
+            }
+
+            if (source.SeqParameterSets != null && source.SeqParameterSets.Count > 0)
+            {
+                clone.SeqParameterSets.AddRange(source.SeqParameterSets);
+            }
+
+            if (source.PicParameterSets != null && source.PicParameterSets.Count > 0)
+            {
+                clone.PicParameterSets.AddRange(source.PicParameterSets);
+            }
+
+            return clone;
+        }
+
+        private static void MergeHevcExtendedData(TSCodecHEVC.ExtendedDataSet target, TSCodecHEVC.ExtendedDataSet source)
+        {
+            if (target == null || source == null)
+            {
+                return;
+            }
+
+            if (source.ExtendedFormatInfo != null)
+            {
+                foreach (string value in source.ExtendedFormatInfo)
+                {
+                    if (!string.IsNullOrEmpty(value) && !target.ExtendedFormatInfo.Contains(value))
+                    {
+                        target.ExtendedFormatInfo.Add(value);
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(target.MasteringDisplayColorPrimaries) && !string.IsNullOrEmpty(source.MasteringDisplayColorPrimaries))
+            {
+                target.MasteringDisplayColorPrimaries = source.MasteringDisplayColorPrimaries;
+            }
+
+            if (string.IsNullOrEmpty(target.MasteringDisplayLuminance) && !string.IsNullOrEmpty(source.MasteringDisplayLuminance))
+            {
+                target.MasteringDisplayLuminance = source.MasteringDisplayLuminance;
+            }
+
+            if (source.MaximumContentLightLevel > target.MaximumContentLightLevel)
+            {
+                target.MaximumContentLightLevel = source.MaximumContentLightLevel;
+            }
+
+            if (source.MaximumFrameAverageLightLevel > target.MaximumFrameAverageLightLevel)
+            {
+                target.MaximumFrameAverageLightLevel = source.MaximumFrameAverageLightLevel;
+            }
+
+            if (source.LightLevelAvailable)
+            {
+                target.LightLevelAvailable = true;
+            }
+
+            if (source.PreferredTransferCharacteristics != 0)
+            {
+                target.PreferredTransferCharacteristics = source.PreferredTransferCharacteristics;
+            }
+
+            if (source.IsHdr10Plus)
+            {
+                target.IsHdr10Plus = true;
+            }
+        }
+
+        private static void UpdatePlaylistVideoReferences(TSPlaylistFile playlist, TSVideoStream clipVideoStream)
+        {
+            if (playlist == null || clipVideoStream == null)
+            {
+                return;
+            }
+
+            if (playlist.PlaylistStreams != null && playlist.PlaylistStreams.TryGetValue(clipVideoStream.PID, out TSStream playlistStream))
+            {
+                MergeVideoStream(playlistStream as TSVideoStream, clipVideoStream);
+            }
+
+            if (playlist.AngleStreams == null)
+            {
+                return;
+            }
+
+            foreach (Dictionary<ushort, TSStream> angleStreamMap in playlist.AngleStreams)
+            {
+                if (angleStreamMap == null)
+                {
+                    continue;
+                }
+
+                if (angleStreamMap.TryGetValue(clipVideoStream.PID, out TSStream angleStream))
+                {
+                    MergeVideoStream(angleStream as TSVideoStream, clipVideoStream);
+                }
             }
         }
 

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1029,11 +1029,128 @@ namespace BDInfo
                             var playlistAudioStream = (TSAudioStream)playlistStream;
                             var clipAudioStream = (TSAudioStream)clipStream;
 
-                            if (clipAudioStream.CoreStream != null)
-                            {
-                                playlistAudioStream.CoreStream = (TSAudioStream)clipAudioStream.CoreStream.Clone();
-                            }
+                            MergeAudioStream(playlistAudioStream, clipAudioStream);
+                            UpdatePlaylistAudioReferences(playlist, clipAudioStream);
                         }
+                    }
+                }
+            }
+        }
+
+        private static void MergeAudioStream(TSAudioStream target, TSAudioStream source)
+        {
+            if (target == null || source == null)
+            {
+                return;
+            }
+
+            if (source.ChannelCount > target.ChannelCount)
+            {
+                target.ChannelCount = source.ChannelCount;
+                target.ChannelLayout = source.ChannelLayout;
+            }
+
+            if (source.LFE > target.LFE)
+            {
+                target.LFE = source.LFE;
+            }
+
+            if (source.SampleRate > target.SampleRate)
+            {
+                target.SampleRate = source.SampleRate;
+            }
+
+            if (source.BitDepth > target.BitDepth)
+            {
+                target.BitDepth = source.BitDepth;
+            }
+
+            if (source.BitRate > target.BitRate)
+            {
+                target.BitRate = source.BitRate;
+            }
+
+            if (source.DialNorm != 0 && (target.DialNorm == 0 || source.DialNorm < target.DialNorm))
+            {
+                target.DialNorm = source.DialNorm;
+            }
+
+            if (source.AudioMode != TSAudioMode.Unknown)
+            {
+                target.AudioMode = source.AudioMode;
+            }
+
+            if (source.HasExtensions != target.HasExtensions)
+            {
+                target.HasExtensions = source.HasExtensions;
+            }
+
+            if (source.ExtendedData != target.ExtendedData)
+            {
+                target.ExtendedData = source.ExtendedData;
+            }
+
+            if (!string.IsNullOrEmpty(source.LanguageCode))
+            {
+                target.LanguageCode = source.LanguageCode;
+            }
+
+            if (!string.IsNullOrEmpty(source.LanguageName))
+            {
+                target.LanguageName = source.LanguageName;
+            }
+
+            if (source.IsInitialized)
+            {
+                target.IsInitialized = true;
+            }
+
+            target.IsVBR = source.IsVBR;
+
+            MergeAudioCoreStream(target, source.CoreStream as TSAudioStream);
+        }
+
+        private static void MergeAudioCoreStream(TSAudioStream target, TSAudioStream sourceCore)
+        {
+            if (target == null || sourceCore == null)
+            {
+                return;
+            }
+
+            if (target.CoreStream == null)
+            {
+                target.CoreStream = (TSAudioStream)sourceCore.Clone();
+            }
+            else
+            {
+                MergeAudioStream(target.CoreStream, sourceCore);
+            }
+        }
+
+        private static void UpdatePlaylistAudioReferences(TSPlaylistFile playlist, TSAudioStream clipAudioStream)
+        {
+            if (playlist == null || clipAudioStream == null)
+            {
+                return;
+            }
+
+            if (playlist.PlaylistStreams != null && playlist.PlaylistStreams.TryGetValue(clipAudioStream.PID, out TSStream playlistStream))
+            {
+                MergeAudioStream(playlistStream as TSAudioStream, clipAudioStream);
+            }
+
+            if (playlist.AngleStreams != null)
+            {
+                foreach (Dictionary<ushort, TSStream> angleStreamMap in playlist.AngleStreams)
+                {
+                    if (angleStreamMap == null)
+                    {
+                        continue;
+                    }
+
+                    if (angleStreamMap.TryGetValue(clipAudioStream.PID, out TSStream angleStream))
+                    {
+                        MergeAudioStream(angleStream as TSAudioStream, clipAudioStream);
                     }
                 }
             }

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -411,6 +411,8 @@ namespace BDInfo
 
                 ScanBDROMResult scanResult = ScanStreamFiles(bdrom, selectedPlaylists, streamFiles);
 
+                UpdatePlaylistStreams(selectedPlaylists);
+
                 if (scanResult.ScanException != null)
                 {
                     throw scanResult.ScanException;
@@ -963,6 +965,79 @@ namespace BDInfo
             progressBar.Report(message, completedBytes + streamFile.Size);
 
             return scanException;
+        }
+
+        private static void UpdatePlaylistStreams(IEnumerable<TSPlaylistFile> playlists)
+        {
+            if (playlists == null)
+            {
+                return;
+            }
+
+            foreach (TSPlaylistFile playlist in playlists)
+            {
+                if (playlist == null)
+                {
+                    continue;
+                }
+
+                foreach (TSStream stream in playlist.Streams.Values)
+                {
+                    if (stream.IsGraphicsStream)
+                    {
+                        var graphicsStream = (TSGraphicsStream)stream;
+                        graphicsStream.Captions = 0;
+                        graphicsStream.ForcedCaptions = 0;
+                    }
+                }
+
+                foreach (TSStreamClip clip in playlist.StreamClips)
+                {
+                    TSStreamFile streamFile = clip?.StreamFile;
+                    if (streamFile == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (TSStream clipStream in streamFile.Streams.Values)
+                    {
+                        if (!playlist.Streams.TryGetValue(clipStream.PID, out TSStream playlistStream))
+                        {
+                            continue;
+                        }
+
+                        if (clipStream.IsGraphicsStream && playlistStream.IsGraphicsStream)
+                        {
+                            var playlistGraphicsStream = (TSGraphicsStream)playlistStream;
+                            var clipGraphicsStream = (TSGraphicsStream)clipStream;
+
+                            playlistGraphicsStream.Captions += clipGraphicsStream.Captions;
+                            playlistGraphicsStream.ForcedCaptions += clipGraphicsStream.ForcedCaptions;
+
+                            if (playlistGraphicsStream.Width == 0 && clipGraphicsStream.Width > 0)
+                            {
+                                playlistGraphicsStream.Width = clipGraphicsStream.Width;
+                            }
+
+                            if (playlistGraphicsStream.Height == 0 && clipGraphicsStream.Height > 0)
+                            {
+                                playlistGraphicsStream.Height = clipGraphicsStream.Height;
+                            }
+                        }
+                        else if (clipStream.IsAudioStream && playlistStream.IsAudioStream)
+                        {
+                            var playlistAudioStream = (TSAudioStream)playlistStream;
+                            var clipAudioStream = (TSAudioStream)clipStream;
+
+                            if (clipAudioStream.CoreStream != null &&
+                                (playlistAudioStream.CoreStream == null || !playlistAudioStream.CoreStream.IsInitialized))
+                            {
+                                playlistAudioStream.CoreStream = (TSAudioStream)clipAudioStream.CoreStream.Clone();
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         private static long GetStreamFileLength(TSStreamFile streamFile)

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1029,8 +1029,7 @@ namespace BDInfo
                             var playlistAudioStream = (TSAudioStream)playlistStream;
                             var clipAudioStream = (TSAudioStream)clipStream;
 
-                            if (clipAudioStream.CoreStream != null &&
-                                (playlistAudioStream.CoreStream == null || !playlistAudioStream.CoreStream.IsInitialized))
+                            if (clipAudioStream.CoreStream != null)
                             {
                                 playlistAudioStream.CoreStream = (TSAudioStream)clipAudioStream.CoreStream.Clone();
                             }

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1029,6 +1029,18 @@ namespace BDInfo
                             var playlistAudioStream = (TSAudioStream)playlistStream;
                             var clipAudioStream = (TSAudioStream)clipStream;
 
+                            if (clipAudioStream.CoreStream != null)
+                            {
+                                if (playlistAudioStream.CoreStream == null)
+                                {
+                                    playlistAudioStream.CoreStream = (TSAudioStream)clipAudioStream.CoreStream.Clone();
+                                }
+                                else if (!playlistAudioStream.CoreStream.IsInitialized && clipAudioStream.CoreStream.IsInitialized)
+                                {
+                                    playlistAudioStream.CoreStream = (TSAudioStream)clipAudioStream.CoreStream.Clone();
+                                }
+                            }
+
                             MergeAudioStream(playlistAudioStream, clipAudioStream);
                             UpdatePlaylistAudioReferences(playlist, clipAudioStream);
                         }

--- a/BDInfo/Report/ReportModels.cs
+++ b/BDInfo/Report/ReportModels.cs
@@ -86,6 +86,7 @@ namespace BDInfo.Reporting
     [DataContract]
     public class AudioStreamData : StreamData
     {
+        [DataMember(EmitDefaultValue = false)] public AudioStreamData CoreStream;
     }
 
     [DataContract]

--- a/BDInfo/Report/ReportModels.cs
+++ b/BDInfo/Report/ReportModels.cs
@@ -81,6 +81,14 @@ namespace BDInfo.Reporting
     [DataContract]
     public class VideoStreamData : StreamData
     {
+        [DataMember(EmitDefaultValue = false)] public List<string> ExtendedFormatInfo;
+        [DataMember(EmitDefaultValue = false)] public string MasteringDisplayColorPrimaries;
+        [DataMember(EmitDefaultValue = false)] public string MasteringDisplayLuminance;
+        [DataMember(EmitDefaultValue = false)] public uint MaximumContentLightLevel;
+        [DataMember(EmitDefaultValue = false)] public uint MaximumFrameAverageLightLevel;
+        [DataMember(EmitDefaultValue = false)] public bool LightLevelAvailable;
+        [DataMember(EmitDefaultValue = false)] public byte PreferredTransferCharacteristics;
+        [DataMember(EmitDefaultValue = false)] public bool IsHdr10Plus;
     }
 
     [DataContract]

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -1048,9 +1048,14 @@ namespace BDInfo.Reporting
             data.AngleIndex = stream.AngleIndex;
             data.BaseView = stream.BaseView;
 
-            if (stream.ExtendedData is string extendedString)
+            switch (stream)
             {
-                data.ExtendedData = extendedString;
+                case TSAudioStream audio when audio.ExtendedData is string audioExtended:
+                    data.ExtendedData = audioExtended;
+                    break;
+                case TSVideoStream video when video.ExtendedData is string videoExtended:
+                    data.ExtendedData = videoExtended;
+                    break;
             }
         }
 

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -865,7 +865,7 @@ namespace BDInfo.Reporting
             StreamData data;
             if (stream is TSVideoStream video)
             {
-                data = new VideoStreamData
+                var videoData = new VideoStreamData
                 {
                     VideoFormat = video.VideoFormat,
                     FrameRate = video.FrameRate,
@@ -877,6 +877,9 @@ namespace BDInfo.Reporting
                     FrameRateDenominator = video.FrameRateDenominator,
                     EncodingProfile = video.EncodingProfile
                 };
+
+                PopulateVideoStreamData(videoData, video);
+                data = videoData;
             }
             else if (stream is TSAudioStream audio)
             {
@@ -934,6 +937,100 @@ namespace BDInfo.Reporting
             return data;
         }
 
+        private static void PopulateVideoStreamData(VideoStreamData data, TSVideoStream video)
+        {
+            if (data == null || video == null)
+            {
+                return;
+            }
+
+            if (video.ExtendedData is TSCodecHEVC.ExtendedDataSet hevcData)
+            {
+                if (hevcData.ExtendedFormatInfo != null && hevcData.ExtendedFormatInfo.Count > 0)
+                {
+                    data.ExtendedFormatInfo = new List<string>(hevcData.ExtendedFormatInfo);
+                }
+
+                if (!string.IsNullOrEmpty(hevcData.MasteringDisplayColorPrimaries))
+                {
+                    data.MasteringDisplayColorPrimaries = hevcData.MasteringDisplayColorPrimaries;
+                }
+
+                if (!string.IsNullOrEmpty(hevcData.MasteringDisplayLuminance))
+                {
+                    data.MasteringDisplayLuminance = hevcData.MasteringDisplayLuminance;
+                }
+
+                if (hevcData.MaximumContentLightLevel != 0)
+                {
+                    data.MaximumContentLightLevel = hevcData.MaximumContentLightLevel;
+                }
+
+                if (hevcData.MaximumFrameAverageLightLevel != 0)
+                {
+                    data.MaximumFrameAverageLightLevel = hevcData.MaximumFrameAverageLightLevel;
+                }
+
+                if (hevcData.LightLevelAvailable)
+                {
+                    data.LightLevelAvailable = true;
+                }
+
+                if (hevcData.PreferredTransferCharacteristics != 0)
+                {
+                    data.PreferredTransferCharacteristics = hevcData.PreferredTransferCharacteristics;
+                }
+
+                if (hevcData.IsHdr10Plus)
+                {
+                    data.IsHdr10Plus = true;
+                }
+            }
+        }
+
+        private static void PopulateVideoExtendedData(TSVideoStream video, VideoStreamData data)
+        {
+            if (video == null || data == null)
+            {
+                return;
+            }
+
+            bool hasHevcInfo =
+                (data.ExtendedFormatInfo != null && data.ExtendedFormatInfo.Count > 0)
+                || !string.IsNullOrEmpty(data.MasteringDisplayColorPrimaries)
+                || !string.IsNullOrEmpty(data.MasteringDisplayLuminance)
+                || data.MaximumContentLightLevel != 0
+                || data.MaximumFrameAverageLightLevel != 0
+                || data.LightLevelAvailable
+                || data.PreferredTransferCharacteristics != 0
+                || data.IsHdr10Plus;
+
+            if (hasHevcInfo)
+            {
+                var extendedData = new TSCodecHEVC.ExtendedDataSet
+                {
+                    MasteringDisplayColorPrimaries = data.MasteringDisplayColorPrimaries ?? string.Empty,
+                    MasteringDisplayLuminance = data.MasteringDisplayLuminance ?? string.Empty,
+                    MaximumContentLightLevel = data.MaximumContentLightLevel,
+                    MaximumFrameAverageLightLevel = data.MaximumFrameAverageLightLevel,
+                    LightLevelAvailable = data.LightLevelAvailable,
+                    PreferredTransferCharacteristics = data.PreferredTransferCharacteristics,
+                    IsHdr10Plus = data.IsHdr10Plus
+                };
+
+                if (data.ExtendedFormatInfo != null && data.ExtendedFormatInfo.Count > 0)
+                {
+                    extendedData.ExtendedFormatInfo.AddRange(data.ExtendedFormatInfo);
+                }
+
+                video.ExtendedData = extendedData;
+            }
+            else if (!string.IsNullOrEmpty(data.ExtendedData))
+            {
+                video.ExtendedData = data.ExtendedData;
+            }
+        }
+
         private static void PopulateCommonStreamData(StreamData data, TSStream stream)
         {
             data.PID = stream.PID;
@@ -950,6 +1047,11 @@ namespace BDInfo.Reporting
             data.PacketSeconds = stream.PacketSeconds;
             data.AngleIndex = stream.AngleIndex;
             data.BaseView = stream.BaseView;
+
+            if (stream.ExtendedData is string extendedString)
+            {
+                data.ExtendedData = extendedString;
+            }
         }
 
         private static TSStream CreateStream(StreamData data)
@@ -981,6 +1083,7 @@ namespace BDInfo.Reporting
                     video.IsInterlaced = data.IsInterlaced;
                     video.FrameRateEnumerator = data.FrameRateEnumerator;
                     video.FrameRateDenominator = data.FrameRateDenominator;
+                    PopulateVideoExtendedData(video, data as VideoStreamData);
                     stream = video;
                     break;
                 }

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -950,7 +950,6 @@ namespace BDInfo.Reporting
             data.PacketSeconds = stream.PacketSeconds;
             data.AngleIndex = stream.AngleIndex;
             data.BaseView = stream.BaseView;
-            data.ExtendedData = stream.ExtendedData as string;
         }
 
         private static TSStream CreateStream(StreamData data)

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -860,7 +860,7 @@ namespace BDInfo.Reporting
             return list;
         }
 
-        private static StreamData CreateStreamData(TSStream stream)
+        private static StreamData CreateStreamData(TSStream stream, bool includeAudioCore = true)
         {
             StreamData data;
             if (stream is TSVideoStream video)
@@ -880,19 +880,7 @@ namespace BDInfo.Reporting
             }
             else if (stream is TSAudioStream audio)
             {
-                data = new AudioStreamData
-                {
-                    SampleRate = audio.SampleRate,
-                    ChannelCount = audio.ChannelCount,
-                    BitDepth = audio.BitDepth,
-                    LFE = audio.LFE,
-                    DialNorm = audio.DialNorm,
-                    HasExtensions = audio.HasExtensions,
-                    AudioMode = audio.AudioMode,
-                    ChannelLayout = audio.ChannelLayout,
-                    ExtendedData = audio.ExtendedData as string,
-                    CoreStreamPID = audio.CoreStream?.PID
-                };
+                data = CreateAudioStreamData(audio, includeAudioCore);
             }
             else if (stream is TSGraphicsStream graphics)
             {
@@ -913,6 +901,41 @@ namespace BDInfo.Reporting
                 data = new StreamData();
             }
 
+            PopulateCommonStreamData(data, stream);
+
+            return data;
+        }
+
+        private static AudioStreamData CreateAudioStreamData(TSAudioStream audio, bool includeAudioCore)
+        {
+            var data = new AudioStreamData
+            {
+                SampleRate = audio.SampleRate,
+                ChannelCount = audio.ChannelCount,
+                BitDepth = audio.BitDepth,
+                LFE = audio.LFE,
+                DialNorm = audio.DialNorm,
+                HasExtensions = audio.HasExtensions,
+                AudioMode = audio.AudioMode,
+                ChannelLayout = audio.ChannelLayout,
+                ExtendedData = audio.ExtendedData as string
+            };
+
+            if (includeAudioCore && audio.CoreStream is TSAudioStream core)
+            {
+                if (core.PID != 0 && !ReferenceEquals(core, audio))
+                {
+                    data.CoreStreamPID = core.PID;
+                }
+
+                data.CoreStream = CreateStreamData(core, false) as AudioStreamData;
+            }
+
+            return data;
+        }
+
+        private static void PopulateCommonStreamData(StreamData data, TSStream stream)
+        {
             data.PID = stream.PID;
             data.StreamType = stream.StreamType;
             data.IsVBR = stream.IsVBR;
@@ -927,13 +950,7 @@ namespace BDInfo.Reporting
             data.PacketSeconds = stream.PacketSeconds;
             data.AngleIndex = stream.AngleIndex;
             data.BaseView = stream.BaseView;
-
-            if (!(stream is TSAudioStream) && stream is TSVideoStream videoStream)
-            {
-                data.ExtendedData = videoStream.ExtendedData as string;
-            }
-
-            return data;
+            data.ExtendedData = stream.ExtendedData as string;
         }
 
         private static TSStream CreateStream(StreamData data)
@@ -1062,12 +1079,30 @@ namespace BDInfo.Reporting
 
             foreach (var streamData in data)
             {
-                if (streamData is AudioStreamData audioData && audioData.CoreStreamPID.HasValue)
+                if (streamData is AudioStreamData audioData &&
+                    audioMap.TryGetValue(streamData.PID, out var audio))
                 {
-                    if (audioMap.TryGetValue(streamData.PID, out var audio) &&
-                        audioMap.TryGetValue(audioData.CoreStreamPID.Value, out var core))
+                    TSAudioStream resolvedCore = null;
+
+                    if (audioData.CoreStreamPID.HasValue &&
+                        audioData.CoreStreamPID.Value != 0 &&
+                        audioData.CoreStreamPID.Value != audio.PID &&
+                        audioMap.TryGetValue(audioData.CoreStreamPID.Value, out var mappedCore))
                     {
-                        audio.CoreStream = core;
+                        resolvedCore = mappedCore;
+                    }
+
+                    if (resolvedCore == null && audioData.CoreStream != null)
+                    {
+                        if (CreateStream(audioData.CoreStream) is TSAudioStream createdCore)
+                        {
+                            resolvedCore = createdCore;
+                        }
+                    }
+
+                    if (resolvedCore != null && audio.CoreStream == null)
+                    {
+                        audio.CoreStream = resolvedCore;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- update the CLI workflow to refresh playlist stream metadata after scanning
- aggregate subtitle caption counts and audio core stream details so text reports mirror the GUI output

## Testing
- dotnet build BDInfo.sln *(fails: requires .NET Framework 4.8 developer pack)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c94447808324a1086f5fcd6dce34)