### PR TITLE
[codex] Fix CLI export edge cases and workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/BDInfo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "nuget"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+-
+
+## Verification
+
+- [ ] `git diff --check`
+- [ ] Visual Studio MSBuild Release build
+- [ ] `BDInfo.exe --help`
+- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
+- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization
+
+## Risk Notes
+
+- GUI impact:
+- CLI impact:
+- Report format/backward compatibility impact:
+
+## Release Notes
+
+-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "**" ]
     tags: [ "v*.*.*" ]    # pushing a tag like v1.2.3 will create/update a GitHub Release
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      # nuget.exe for classic packages.config restore.
+      # nuget.exe restore also supports this project's PackageReference dependencies.
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v2
 
@@ -37,6 +38,43 @@ jobs:
           $out = (Resolve-Path $dist).Path + "\"
           & msbuild BDInfo.sln /p:Configuration=Release /p:Platform="Any CPU" /p:OutDir="$out" /m
           Write-Host "Built to ${out}"
+
+      - name: Smoke test CLI entrypoint
+        shell: pwsh
+        run: |
+          $exe = Join-Path $PWD "dist\BDInfo.exe"
+          if (!(Test-Path $exe)) {
+            throw "BDInfo.exe was not built at $exe"
+          }
+
+          $help = & $exe --help
+          $exitCode = $LASTEXITCODE
+          $help | Write-Host
+
+          if ($exitCode -ne 0) {
+            throw "BDInfo.exe --help exited with code $exitCode"
+          }
+
+          if (($help -join "`n") -notmatch "Options:") {
+            throw "BDInfo.exe --help output did not contain the expected Options section"
+          }
+
+      - name: Verify build output
+        shell: pwsh
+        run: |
+          $required = @(
+            "BDInfo.exe",
+            "BDInfo.exe.config",
+            "DiscUtils.dll",
+            "ZedGraph.dll"
+          )
+
+          foreach ($file in $required) {
+            $path = Join-Path "dist" $file
+            if (!(Test-Path $path)) {
+              throw "Required build output is missing: $path"
+            }
+          }
 
       # Package everything from dist/ into a single ZIP at repository root.
       - name: Package ZIP for Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md
+
+This repository is a long-lived personal fork of BDInfo. Treat it as a production tool even when changes are small: preserve GUI behavior, keep CLI behavior explicit, and verify report round-trips before shipping.
+
+## Operating Rules
+
+- Work from a clean, named branch for every task. Use `codex/<short-task-name>` unless the user asks for another branch name.
+- Do not commit directly to `UHD_Support` for normal work. Open a pull request back into `UHD_Support`.
+- Never rewrite or discard user changes. If the worktree is dirty, inspect it first and keep unrelated edits intact.
+- Keep changes scoped. Avoid broad refactors unless the task is specifically a refactor.
+- Prefer small, reviewable commits. One bug fix or workflow change per commit is the default.
+- Do not push until local verification has passed and the user has agreed to publish the branch.
+
+## Build Commands
+
+This is a classic .NET Framework WinForms project. Use Visual Studio MSBuild, not `dotnet build`, for authoritative local builds.
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /t:Restore /p:Configuration=Release /p:Platform='Any CPU'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
+```
+
+If MSBuild is not at that path, locate it with:
+
+```powershell
+& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+```
+
+## Required Verification
+
+For any code change:
+
+```powershell
+git diff --check
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
+& .\BDInfo\bin\Release\BDInfo.exe --help
+```
+
+For CLI/report/export changes, also run a real-disc smoke when a decrypted BD root is available, for example `V:\`:
+
+```powershell
+$out = 'C:\dev\BDInfo_clicli\tmp_smoke_V'
+if (Test-Path $out) { Remove-Item -LiteralPath $out -Recurse -Force }
+New-Item -ItemType Directory -Path $out | Out-Null
+
+& .\BDInfo\bin\Release\BDInfo.exe V:\ $out --list
+& .\BDInfo\bin\Release\BDInfo.exe V:\ "$out\plain" -m 00016 -r txt,bdinfo,bdinfo-json --charts jpg
+& .\BDInfo\bin\Release\BDInfo.exe V:\ "$out\compressed" -m 00016 -r bdinfo,bdinfo-json --compress
+```
+
+Clean temporary smoke output before committing.
+
+## Review Checklist
+
+Before finalizing a PR, verify:
+
+- GUI launch with no arguments still opens the GUI.
+- GUI launch with a single path argument still opens the GUI and loads that path/report.
+- CLI mode is entered only for explicit CLI usage, such as options or source plus destination.
+- Text, XML `.bdinfo`, JSON `.bdinfo`, and compressed `.bdinfo` exports do not overwrite each other unexpectedly.
+- Exported `.bdinfo` files load back into the GUI and can regenerate reports/charts without the original disc.
+- README/help text matches the actual CLI behavior.
+
+## GitHub Workflow
+
+- Open a PR for each task. Do not batch unrelated findings.
+- Fill in `.github/pull_request_template.md`.
+- Wait for GitHub Actions to pass before merging.
+- Dependabot is enabled for NuGet packages and GitHub Actions. Treat its PRs like normal code changes: review the diff, wait for CI, and merge only when the update is relevant.
+- Use tag pushes for releases. The build workflow attaches `BDInfo_clicli.zip` to tags matching `v*.*.*`.
+- Suggested tag format for this fork: `v0.7.6.2-clicli.N`.
+
+Recommended GitHub repository settings:
+
+- Protect `UHD_Support`.
+- Require the `Build (BDInfo_clicli)` workflow before merging.
+- Require pull requests before merging to `UHD_Support`.
+- Disable force pushes on protected branches.
+
+## Commit Style
+
+Use concise imperative commit messages:
+
+```text
+Fix CLI report export edge cases
+Add PR workflow documentation
+Harden BDInfo report round-trip loading
+```
+
+In commit bodies, include the important verification commands when the change touches CLI, reports, or CI.

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -52,6 +52,11 @@ namespace BDInfo
                 return false;
             }
 
+            if (!ShouldHandle(args))
+            {
+                return false;
+            }
+
             using (ConsoleWindow.EnsureAttached())
             {
                 CliOptions options;
@@ -99,6 +104,31 @@ namespace BDInfo
 
                 return true;
             }
+        }
+
+        private static bool ShouldHandle(string[] args)
+        {
+            bool hasOption = false;
+            int positionalCount = 0;
+
+            foreach (string arg in args)
+            {
+                if (string.IsNullOrWhiteSpace(arg))
+                {
+                    continue;
+                }
+
+                if (arg.StartsWith("-", StringComparison.Ordinal))
+                {
+                    hasOption = true;
+                }
+                else
+                {
+                    positionalCount++;
+                }
+            }
+
+            return hasOption || positionalCount > 1;
         }
 
         private static CliOptions ParseArguments(string[] args)
@@ -152,6 +182,14 @@ namespace BDInfo
                 {
                     string value = ExtractOptionValue(args, ref i, "-c", "--charts", allowMissingValue: true);
                     options.SaveCharts = true;
+                    if (string.IsNullOrWhiteSpace(value) &&
+                        i + 1 < args.Length &&
+                        IsChartFormatName(args[i + 1]))
+                    {
+                        i++;
+                        value = args[i];
+                    }
+
                     if (!string.IsNullOrWhiteSpace(value))
                     {
                         options.ChartFormat = value;
@@ -1563,11 +1601,15 @@ namespace BDInfo
 
             if (formats.Contains(ReportFormat.BdinfoJson))
             {
-                string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
-                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json, compress);
-                writtenPaths.Add(reportPath);
+                string jsonFileName = formats.Contains(ReportFormat.Bdinfo)
+                    ? sanitizedBaseName + ".json.bdinfo"
+                    : sanitizedBaseName + ".bdinfo";
+                string jsonReportPath = Path.Combine(destination, jsonFileName);
+                BDInfoReportSerializer.Save(jsonReportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json, compress);
+                writtenPaths.Add(jsonReportPath);
             }
-            else if (formats.Contains(ReportFormat.Bdinfo))
+
+            if (formats.Contains(ReportFormat.Bdinfo))
             {
                 string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
                 BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml, compress);
@@ -1661,6 +1703,28 @@ namespace BDInfo
             }
         }
 
+        private static bool IsChartFormatName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            switch (name.Trim().ToLowerInvariant())
+            {
+                case "png":
+                case "jpg":
+                case "jpeg":
+                case "bmp":
+                case "gif":
+                case "tif":
+                case "tiff":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         private static string GetVersionString()
         {
             return Application.ProductVersion;
@@ -1678,7 +1742,7 @@ namespace BDInfo
             Console.WriteLine("  -m, --mpls=VALUE           Comma separated list of playlists to scan.");
             Console.WriteLine("  -w, --whole                Scan whole disc - every playlist.");
             Console.WriteLine("  -v, --version              Print the version.");
-            Console.WriteLine("  -c, --charts               Save all charts as image (select image format, default png)");
+            Console.WriteLine("  -c, --charts[=FORMAT]      Save all charts as image (png by default; also jpg, bmp, gif, tiff).");
             Console.WriteLine("  -r, --report               Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.");
             Console.WriteLine("  -z, --compress             Compress generated .bdinfo reports using ZIP.");
         }

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1193,7 +1193,13 @@ namespace BDInfo
                                 compress = true;
                                 break;
                             case 5:
-                                using (var writer = new StreamWriter(dialog.FileName, false, Encoding.UTF8))
+                                string textFileName = dialog.FileName;
+                                if (!string.Equals(Path.GetExtension(textFileName), ".txt", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    textFileName = Path.ChangeExtension(textFileName, ".txt");
+                                }
+
+                                using (var writer = new StreamWriter(textFileName, false, Encoding.UTF8))
                                 {
                                     writer.Write(textBoxReport.Text);
                                 }

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -55,7 +55,12 @@ namespace BDInfo.Reporting
                 ScanResult = ConvertScanResult(scanResult)
             };
 
-            Directory.CreateDirectory(Path.GetDirectoryName(path) ?? ".");
+            string directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                directory = ".";
+            }
+            Directory.CreateDirectory(directory);
 
             if (compress)
             {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   -m, --mpls=VALUE           Comma separated list of playlists to scan.
   -w, --whole                Scan whole disc - every playlist.
   -v, --version              Print the version.
-  -c, --charts               Save all charts as image (select image format, default png)
+  -c, --charts[=FORMAT]      Save all charts as image (png by default; also jpg, bmp, gif, tiff).
   -r, --report               Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.
   -z, --compress             Compress generated .bdinfo reports using ZIP.
 ```
@@ -69,9 +69,32 @@ Fixed an issue where loading an HDR10+ title first could cause a subsequent non�
 ---
 
 ## Build from source
-1. Open `BDInfo.sln` in Visual Studio.
-2. Target **.NET Framework 4.7.2+**.
+1. Open `BDInfo.sln` in Visual Studio, or build with Visual Studio MSBuild.
+2. Target **.NET Framework 4.8**.
 3. Build the **BDInfo** solution.
+
+Authoritative local build commands:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /t:Restore /p:Configuration=Release /p:Platform='Any CPU'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
+```
+
+`dotnet build` is not the supported build path for this classic .NET Framework WinForms project.
+
+---
+
+## Development workflow
+Normal changes should be made on a short-lived branch and reviewed through a pull request into `UHD_Support`.
+
+Required checks before publishing a branch:
+- `git diff --check`
+- Visual Studio MSBuild Release build
+- `BDInfo.exe --help`
+- Real-disc CLI smoke for CLI/report/chart changes
+- `.bdinfo` round-trip check for report serialization changes
+
+Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.
 
 ---
 
@@ -90,7 +113,7 @@ Common options:
 - `-m, --mpls=VALUE` – comma‑separated playlist IDs to scan (e.g., `-m 800,801`)
 - `-w, --whole` – scan **all** playlists
 - `-r, --report` – choose report formats: `txt`, `bdinfo`, `bdinfo-json` (comma‑separate for multiple)
-- `-c, --charts` – save bitrate charts as images (default **png**)
+- `-c, --charts[=FORMAT]` – save bitrate charts as images (default **png**; also `jpg`, `bmp`, `gif`, `tiff`)
 - `-z, --compress` – Compress generated .bdinfo reports using ZIP
 
 

--- a/README_CLICLI.MD
+++ b/README_CLICLI.MD
@@ -35,8 +35,9 @@ Options:
   -m, --mpls=VALUE           Comma separated list of playlists to scan.
   -w, --whole                Scan whole disc - every playlist.
   -v, --version              Print the version.
-  -c, --charts               Save all charts as image (select image format, default png)
+  -c, --charts[=FORMAT]      Save all charts as image (png by default; also jpg, bmp, gif, tiff).
   -r, --report               Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.
+  -z, --compress             Compress generated .bdinfo reports using ZIP.
 ```
 
 ---
@@ -68,9 +69,32 @@ Fixed an issue where loading an HDR10+ title first could cause a subsequent non�
 ---
 
 ## Build from source
-1. Open `BDInfo.sln` in Visual Studio.
-2. Target **.NET Framework 4.7.2+**.
+1. Open `BDInfo.sln` in Visual Studio, or build with Visual Studio MSBuild.
+2. Target **.NET Framework 4.8**.
 3. Build the **BDInfo** solution.
+
+Authoritative local build commands:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /t:Restore /p:Configuration=Release /p:Platform='Any CPU'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
+```
+
+`dotnet build` is not the supported build path for this classic .NET Framework WinForms project.
+
+---
+
+## Development workflow
+Normal changes should be made on a short-lived branch and reviewed through a pull request into `UHD_Support`.
+
+Required checks before publishing a branch:
+- `git diff --check`
+- Visual Studio MSBuild Release build
+- `BDInfo.exe --help`
+- Real-disc CLI smoke for CLI/report/chart changes
+- `.bdinfo` round-trip check for report serialization changes
+
+Codex/agent operating rules live in `AGENTS.md`. Pull requests should use the repository PR template.
 
 ---
 
@@ -89,7 +113,8 @@ Common options:
 - `-m, --mpls=VALUE` – comma‑separated playlist IDs to scan (e.g., `-m 800,801`)
 - `-w, --whole` – scan **all** playlists
 - `-r, --report` – choose report formats: `txt`, `bdinfo`, `bdinfo-json` (comma‑separate for multiple)
-- `-c, --charts` – save bitrate charts as images (default **png**)
+- `-c, --charts[=FORMAT]` – save bitrate charts as images (default **png**; also `jpg`, `bmp`, `gif`, `tiff`)
+- `-z, --compress` – compress generated `.bdinfo` reports using ZIP
 
 ---
 
@@ -108,4 +133,3 @@ LGPL‑2.1 (same as the original BDInfo).
 - Original **BDInfo** by Cinema Squid.
 - Upstream fork: **UniqProject/BDInfo** (`v0.7.6.2_1b`).
 - This fork: CLI mode, GUI export/reload, JSON/XML report support, HDR10+ bug fix.
-


### PR DESCRIPTION
## Summary

- Fix CLI/GUI dispatch so a single path argument still opens the GUI while explicit CLI usage remains supported.
- Fix report export edge cases: XML and JSON `.bdinfo` outputs no longer overwrite each other, `--charts jpg` is accepted, relative serializer paths are handled, and GUI text export uses `.txt`.
- Add Codex/GitHub workflow documentation, PR template, Dependabot configuration, and CI smoke checks for `BDInfo.exe --help` plus required build outputs.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke on `V:\` using `00016.MPLS`
- [x] Exported `.bdinfo` round-trip checked for XML/JSON and compressed/uncompressed files

## Risk Notes

- GUI impact: restores single-path GUI launch behavior and normalizes text export extension.
- CLI impact: `--charts jpg` and `--charts=jpg` both work; dual XML/JSON export writes separate files.
- Report format/backward compatibility impact: no schema change; compressed and uncompressed XML/JSON still auto-detect on load.

## Release Notes

- Hardened CLI report export and documented the new Codex/GitHub workflow.
