### PR TITLE
[codex] Preserve custom playlist scan metrics

### DIFF
--- a/BDInfo/BDROM/TSPlaylistFile.cs
+++ b/BDInfo/BDROM/TSPlaylistFile.cs
@@ -112,6 +112,11 @@ namespace BDInfo
                 newClip.RelativeTimeIn = TotalLength;
                 newClip.RelativeTimeOut = newClip.RelativeTimeIn + newClip.Length;
                 newClip.AngleIndex = clip.AngleIndex;
+                newClip.FileSize = clip.FileSize;
+                newClip.InterleavedFileSize = clip.InterleavedFileSize;
+                newClip.PayloadBytes = clip.PayloadBytes;
+                newClip.PacketCount = clip.PacketCount;
+                newClip.PacketSeconds = clip.PacketSeconds;
                 newClip.Chapters.Add(clip.TimeIn);
                 StreamClips.Add(newClip);
 
@@ -123,6 +128,10 @@ namespace BDInfo
                 {
                     Chapters.Add(newClip.RelativeTimeIn);
                 }
+            }
+            foreach (TSStreamClip clip in StreamClips)
+            {
+                clip.RelativeLength = TotalLength > 0 ? clip.Length / TotalLength : 0;
             }
             LoadStreamClips();
             IsInitialized = true;


### PR DESCRIPTION
## Summary

- Preserve scan-derived metrics when building a custom playlist from existing clips.
- Keep custom playlists created after loading an exported `.bdinfo` from showing zero size/bitrate values.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: Custom playlist reports now retain clip packet metrics after loading an exported report without the original disc.
- CLI impact: None expected.
- Report format/backward compatibility impact: None; no serialization schema changes.

## Release Notes

- Fixed custom playlist size and bitrate values after reopening exported BDInfo reports.
