### PR TITLE
[codex] Avoid overwriting CLI chart exports

### DIFF
--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1649,6 +1649,7 @@ namespace BDInfo
 
             foreach (TSPlaylistFile playlist in playlists)
             {
+                bool qualifyNames = playlist.VideoStreams.Count > 1 || playlist.AngleStreams.Count > 0;
                 foreach (TSVideoStream videoStream in playlist.VideoStreams)
                 {
                     for (int angleIndex = 0; angleIndex <= playlist.AngleStreams.Count; angleIndex++)
@@ -1661,7 +1662,10 @@ namespace BDInfo
                                 {
                                     chart.CreateControl();
                                     chart.Generate(chartType, playlist, videoStream.PID, angleIndex);
-                                    chart.SaveChartImage(directory, format, extension);
+                                    string qualifier = qualifyNames
+                                        ? string.Format(CultureInfo.InvariantCulture, "pid-{0:X4}-angle-{1}", videoStream.PID, angleIndex)
+                                        : null;
+                                    chart.SaveChartImage(directory, format, extension, qualifier);
                                     savedCount++;
                                 }
                             }

--- a/BDInfo/FormChart.cs
+++ b/BDInfo/FormChart.cs
@@ -152,7 +152,8 @@ namespace BDInfo
         public string SaveChartImage(
             string directory,
             ImageFormat format,
-            string extension)
+            string extension,
+            string nameQualifier = null)
         {
             if (string.IsNullOrWhiteSpace(directory))
             {
@@ -173,6 +174,14 @@ namespace BDInfo
 
             string baseName = Path.GetFileNameWithoutExtension(DefaultFileName);
             string safeName = ToolBox.GetSafeFileName(baseName);
+            if (!string.IsNullOrWhiteSpace(nameQualifier))
+            {
+                string safeQualifier = ToolBox.GetSafeFileName(nameQualifier);
+                if (!string.IsNullOrWhiteSpace(safeQualifier))
+                {
+                    safeName += "-" + safeQualifier;
+                }
+            }
             string fileName = safeName + extension;
             string fullPath = Path.Combine(directory, fileName);
 


### PR DESCRIPTION
## Summary

- Add unique CLI chart file suffixes when a playlist has multiple video streams or angles.
- Preserve existing chart file names for the common single-video, no-angle case.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: None expected; GUI chart save path still uses the default file name unless a caller passes a qualifier.
- CLI impact: Multi-video/angle chart exports now write distinct files instead of overwriting previous charts. Single-video names remain unchanged.
- Report format/backward compatibility impact: None; no report schema or serialization changes.

## Release Notes

- Fixed CLI chart export overwrites for playlists with multiple video streams or angles.
