### PR TITLE
[codex] Harden report generation edge cases

### DIFF
--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -803,7 +803,9 @@ namespace BDInfo
                 double chapterMaxFrameSize = 0;
                 double chapterMaxFrameLocation = 0;
 
-                ushort diagPID  = playlist.VideoStreams[0].PID;
+                ushort? diagPID = playlist.VideoStreams.Count > 0
+                    ? playlist.VideoStreams[0].PID
+                    : (ushort?)null;
 
                 int chapterIndex = 0;
                 int clipIndex = 0;
@@ -837,9 +839,10 @@ namespace BDInfo
                     if (clip != null &&
                         clip.AngleIndex == 0 &&
                         file != null &&
-                        file.StreamDiagnostics.ContainsKey(diagPID))
+                        diagPID.HasValue &&
+                        file.StreamDiagnostics.ContainsKey(diagPID.Value))
                     {
-                        diagList = file.StreamDiagnostics[diagPID];
+                        diagList = file.StreamDiagnostics[diagPID.Value];
 
                         while (diagIndex < diagList.Count &&
                             chapterPosition < chapterEnd)
@@ -1125,8 +1128,14 @@ namespace BDInfo
             }
 
             textBoxReport.Select(0, 0);
-            comboBoxPlaylist.SelectedIndex = 0;
-            comboBoxChartType.SelectedIndex = 0;
+            if (comboBoxPlaylist.Items.Count > 0)
+            {
+                comboBoxPlaylist.SelectedIndex = 0;
+            }
+            if (comboBoxChartType.Items.Count > 0)
+            {
+                comboBoxChartType.SelectedIndex = 0;
+            }
         }
 
         private void buttonCopy_Click(
@@ -1260,6 +1269,12 @@ namespace BDInfo
             TSPlaylistFile playlist = (TSPlaylistFile)comboBoxPlaylist.SelectedItem;
 
             comboBoxAngle.Items.Clear();
+            comboBoxStream.Items.Clear();
+            if (playlist == null)
+            {
+                return;
+            }
+
             for (int i = 0; i <= playlist.AngleStreams.Count; i++)
             {
                 comboBoxAngle.Items.Add(i);
@@ -1269,7 +1284,6 @@ namespace BDInfo
                 comboBoxAngle.SelectedIndex = 0;
             }
 
-            comboBoxStream.Items.Clear();
             foreach (TSVideoStream videoStream in playlist.VideoStreams)
             {
                 comboBoxStream.Items.Add(videoStream);


### PR DESCRIPTION
## Summary

- Harden `FormReport` generation for reports or playlist selections that have no video streams.
- Avoid `SelectedIndex = 0` crashes when report generation has no playlist items.
- Make playlist selection handling tolerate a null selection while clearing dependent chart controls.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: Report windows remain openable for empty/no-video edge cases; chart controls simply stay empty when there is nothing chartable.
- CLI impact: None expected beyond using the same report generation path for text reports.
- Report format/backward compatibility impact: None; no report schema or serialization changes.

## Release Notes

- Fixed report generation crashes for no-video and empty-playlist edge cases.
