### PR TITLE
[codex] Update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Put MSBuild into PATH (for .NET Framework builds).
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       # nuget.exe restore also supports this project's PackageReference dependencies.
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
+        uses: NuGet/setup-nuget@v4
 
       - name: Restore NuGet packages
         run: nuget restore BDInfo.sln
@@ -87,7 +87,7 @@ jobs:
 
       # Upload only one artifact with simplified paths (no /bin/ in structure).
       - name: Upload artifact (files only)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: BDInfo_clicli
           path: dist/**
@@ -96,7 +96,7 @@ jobs:
       # On tag pushes (v*.*.*), create/update a GitHub Release and attach the ZIP.
       - name: Create GitHub Release (on tag)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             BDInfo_clicli.zip


### PR DESCRIPTION
## Summary

- Update GitHub Actions dependencies to current major versions that run on Node 24.
- Keep the existing build, smoke test, artifact upload, and tag release flow unchanged.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: None.
- CLI impact: None.
- Report format/backward compatibility impact: None.
- CI impact: This intentionally changes only GitHub Actions action versions; PR CI is the authoritative validation.

## Release Notes

- Updated GitHub Actions runtime versions to avoid Node 20 deprecation warnings.
