### PR TITLE
Harden scan result loading

### DIFF
--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -587,6 +587,11 @@ namespace BDInfo.Reporting
             {
                 foreach (var fileException in data.FileExceptions)
                 {
+                    if (fileException == null)
+                    {
+                        continue;
+                    }
+
                     var message = fileException.Message ?? string.Empty;
                     if (!string.IsNullOrWhiteSpace(fileException.StackTrace))
                     {


### PR DESCRIPTION
## Summary

- Skip null entries in saved scan file-exception lists when restoring report scan results.
- Preserve existing scan exception and file exception restoration behavior for valid entries.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: partial `.bdinfo` files with sparse scan error data should load more reliably.
- CLI impact: no intended CLI behavior change.
- Report format/backward compatibility impact: tolerant reader change only; report schema is unchanged.

## Release Notes

- Hardened report scan-result loading against null file-exception entries.