### PR TITLE
Reduce duplicate CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build (BDInfo_clicli)
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "UHD_Support" ]
     tags: [ "v*.*.*" ]    # pushing a tag like v1.2.3 will create/update a GitHub Release
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Restrict push-triggered builds to `UHD_Support` and release tags.
- Keep pull request builds enabled for feature branches.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: none.
- CLI impact: none.
- Report format/backward compatibility impact: none.
- CI impact: feature branch pushes no longer run a duplicate build before the PR build; `UHD_Support`, PRs, manual dispatch, and release tags still build.

## Release Notes

- Reduced duplicate CI runs for pull-request branches.