### PR TITLE
Harden chart filenames without volume label

### DIFF
--- a/BDInfo/FormChart.cs
+++ b/BDInfo/FormChart.cs
@@ -196,6 +196,11 @@ namespace BDInfo
         private string FixVolumeLabel(string label)
         {
             // TODO: Other Volume Label Tweaks?
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                return "UNKNOWN";
+            }
+
             return label.Replace(" ", "_");
         }
 


### PR DESCRIPTION
## Summary

- Use `UNKNOWN` as the chart filename prefix when the disc/report has no volume label.
- Preserve existing space-to-underscore chart filename behavior for normal labels.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: chart generation from reports without a volume label should no longer fail during filename creation.
- CLI impact: `--charts` can save files even when `BDROM.VolumeLabel` is missing.
- Report format/backward compatibility impact: none.

## Release Notes

- Hardened chart image filename generation for discs or reports without a volume label.