### PR TITLE
Harden GUI report export name

### DIFF
--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1164,7 +1164,13 @@ namespace BDInfo
             {
                 defaultName = "BDINFO";
             }
-            defaultName = ToolBox.GetSafeFileName(defaultName) + ".bdinfo";
+
+            defaultName = ToolBox.GetSafeFileName(defaultName);
+            if (string.IsNullOrWhiteSpace(defaultName))
+            {
+                defaultName = "BDINFO";
+            }
+            defaultName += ".bdinfo";
 
             using (SaveFileDialog dialog = new SaveFileDialog())
             {


### PR DESCRIPTION
## Summary

- Add a second fallback for the GUI report export default filename after sanitizing the volume label.
- Align GUI export naming with the CLI's defensive `BDINFO` fallback for unusable labels.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: SaveFileDialog default filename is more robust for unusual volume labels.
- CLI impact: none.
- Report format/backward compatibility impact: none.

## Release Notes

- Hardened the GUI report export default filename for unusual disc labels.