### PR TITLE
Harden CLI short option parsing

### DIFF
--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -167,7 +167,7 @@ namespace BDInfo
                     continue;
                 }
 
-                if (IsOption(arg, "-m", "--mpls"))
+                if (IsOption(arg, "-m", "--mpls", allowShortValue: true))
                 {
                     string value = ExtractOptionValue(args, ref i, "-m", "--mpls");
                     if (string.IsNullOrWhiteSpace(value))
@@ -203,7 +203,7 @@ namespace BDInfo
                     continue;
                 }
 
-                if (IsOption(arg, "-r", "--report"))
+                if (IsOption(arg, "-r", "--report", allowShortValue: true))
                 {
                     string value = ExtractOptionValue(args, ref i, "-r", "--report");
                     if (string.IsNullOrWhiteSpace(value))
@@ -267,7 +267,7 @@ namespace BDInfo
                    || string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsOption(string value, string shortOption, string longOption)
+        private static bool IsOption(string value, string shortOption, string longOption, bool allowShortValue = false)
         {
             if (string.Equals(value, shortOption, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(value, longOption, StringComparison.OrdinalIgnoreCase))
@@ -289,6 +289,7 @@ namespace BDInfo
 
             if (!string.IsNullOrEmpty(shortOption)
                 && shortOption.Length == 2
+                && allowShortValue
                 && value.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase)
                 && value.Length > shortOption.Length
                 && value[shortOption.Length] != '=')


### PR DESCRIPTION
## Summary

- Stop boolean short options from accepting arbitrary attached text.
- Keep attached values available for value-taking options such as `-m00107` and `-rtext`.
- Make single-dash long typos like `-list`, `-whole`, and `-compress` fail as unknown options instead of silently entering another mode.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

Additional parser checks:

- `BDInfo.exe V:\ -list` rejects with `Unknown option: -list`
- `BDInfo.exe V:\ -whole` rejects with `Unknown option: -whole`
- `BDInfo.exe V:\ -compress` rejects with `Unknown option: -compress`
- `BDInfo.exe V:\ <out> -m00107 -rtext --charts jpg` scans and writes the report/charts

## Risk Notes

- GUI impact: none.
- CLI impact: invalid single-dash long spellings now fail early with a clearer error.
- Report format/backward compatibility impact: none.

## Release Notes

- Hardened CLI option parsing for mistyped single-dash long options.