### PR TITLE
Harden CLI long flag parsing

### DIFF
--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -167,7 +167,7 @@ namespace BDInfo
                     continue;
                 }
 
-                if (IsOption(arg, "-m", "--mpls", allowShortValue: true))
+                if (IsOption(arg, "-m", "--mpls", allowShortValue: true, allowLongValue: true))
                 {
                     string value = ExtractOptionValue(args, ref i, "-m", "--mpls");
                     if (string.IsNullOrWhiteSpace(value))
@@ -178,7 +178,7 @@ namespace BDInfo
                     continue;
                 }
 
-                if (IsOption(arg, "-c", "--charts"))
+                if (IsOption(arg, "-c", "--charts", allowLongValue: true))
                 {
                     string value = ExtractOptionValue(args, ref i, "-c", "--charts", allowMissingValue: true);
                     options.SaveCharts = true;
@@ -203,7 +203,7 @@ namespace BDInfo
                     continue;
                 }
 
-                if (IsOption(arg, "-r", "--report", allowShortValue: true))
+                if (IsOption(arg, "-r", "--report", allowShortValue: true, allowLongValue: true))
                 {
                     string value = ExtractOptionValue(args, ref i, "-r", "--report");
                     if (string.IsNullOrWhiteSpace(value))
@@ -267,7 +267,7 @@ namespace BDInfo
                    || string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool IsOption(string value, string shortOption, string longOption, bool allowShortValue = false)
+        private static bool IsOption(string value, string shortOption, string longOption, bool allowShortValue = false, bool allowLongValue = false)
         {
             if (string.Equals(value, shortOption, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(value, longOption, StringComparison.OrdinalIgnoreCase))
@@ -276,6 +276,7 @@ namespace BDInfo
             }
 
             if (!string.IsNullOrEmpty(longOption)
+                && allowLongValue
                 && value.StartsWith(longOption + "=", StringComparison.OrdinalIgnoreCase))
             {
                 return true;


### PR DESCRIPTION
## Summary

- Stop boolean long options from accepting `=value` suffixes.
- Keep `--mpls=...`, `--charts=...`, and `--report=...` working for options that actually take values.
- Make mistakes such as `--list=false`, `--whole=false`, and `--compress=false` fail with an unknown-option error instead of silently enabling the flag.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

Additional parser checks:

- `BDInfo.exe V:\ --list=false` rejects with `Unknown option: --list=false`
- `BDInfo.exe V:\ --whole=false` rejects with `Unknown option: --whole=false`
- `BDInfo.exe V:\ --compress=false` rejects with `Unknown option: --compress=false`
- `BDInfo.exe V:\ <out> --mpls=00107 --report=txt --charts=jpg` scans and writes the report/charts

## Risk Notes

- GUI impact: none.
- CLI impact: invalid `=value` suffixes on boolean flags now fail early with a clearer error.
- Report format/backward compatibility impact: none.

## Release Notes

- Hardened CLI parsing for boolean long options with accidental values.