### PR TITLE
Set release workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary

- Add explicit `contents: write` permissions to the build workflow.
- Keep release creation robust when repository default `GITHUB_TOKEN` permissions are read-only.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: none.
- CLI impact: none.
- Report format/backward compatibility impact: none.
- CI/release impact: tag builds retain permission to create/update GitHub releases and upload `BDInfo_clicli.zip`.

## Release Notes

- Made release workflow permissions explicit.