### PR TITLE
Fix artifact workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Add explicit `actions: write` permission required by `actions/upload-artifact` when workflow permissions are declared.
- Keep `contents: write` for tag release creation.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: none.
- CLI impact: none.
- Report format/backward compatibility impact: none.
- CI/release impact: fixes artifact upload after explicit workflow permissions were added.

## Release Notes

- Fixed GitHub Actions artifact upload permissions.