### PR TITLE
Skip artifact upload for fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
 
       # Upload only one artifact with simplified paths (no /bin/ in structure).
       - name: Upload artifact (files only)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@v7
         with:
           name: BDInfo_clicli


### PR DESCRIPTION
## Summary

- Skip artifact upload for pull requests opened from forks.
- Keep artifact upload enabled for pushes, manual runs, tags, and PR branches from this repository.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: none.
- CLI impact: none.
- Report format/backward compatibility impact: none.
- CI impact: fork PRs still build and smoke-test, but skip artifact upload that may require unavailable write permissions.

## Release Notes

- Made PR CI more robust for forked pull requests.