### PR TITLE
Harden chart empty buckets

### DIFF
--- a/BDInfo/FormChart.cs
+++ b/BDInfo/FormChart.cs
@@ -204,6 +204,29 @@ namespace BDInfo
             return label.Replace(" ", "_");
         }
 
+        private static void AddAggregatePoint(
+            PointPairList pointsMin,
+            PointPairList pointsAvg,
+            PointPairList pointsMax,
+            double pointMinutes,
+            double pointMin,
+            double pointAvg,
+            double pointMax,
+            int pointCount)
+        {
+            if (pointCount <= 0)
+            {
+                pointsMin.Add(pointMinutes, 0);
+                pointsAvg.Add(pointMinutes, 0);
+                pointsMax.Add(pointMinutes, 0);
+                return;
+            }
+
+            pointsMin.Add(pointMinutes, pointMin);
+            pointsAvg.Add(pointMinutes, pointAvg / pointCount);
+            pointsMax.Add(pointMinutes, pointMax);
+        }
+
         public void GenerateWindowChart(
             TSPlaylistFile playlist,
             ushort PID,
@@ -283,9 +306,7 @@ namespace BDInfo
                         if (pointPosition >= pointSeconds)
                         {
                             double pointMinutes = (pointSeconds - 1) / 60;
-                            pointsMin.Add(pointMinutes, pointMin);
-                            pointsMax.Add(pointMinutes, pointMax);
-                            pointsAvg.Add(pointMinutes, pointAvg / pointCount);
+                            AddAggregatePoint(pointsMin, pointsAvg, pointsMax, pointMinutes, pointMin, pointAvg, pointMax, pointCount);
                             pointMin = double.MaxValue;
                             pointMax = 0;
                             pointAvg = 0;
@@ -308,9 +329,7 @@ namespace BDInfo
                             pointSeconds += 1;
                         }
                         double pointMinutes = (pointSeconds - 1) / 60;
-                        pointsMin.Add(pointMinutes, pointMin);
-                        pointsAvg.Add(pointMinutes, pointAvg / pointCount);
-                        pointsMax.Add(pointMinutes, pointMax);
+                        AddAggregatePoint(pointsMin, pointsAvg, pointsMax, pointMinutes, pointMin, pointAvg, pointMax, pointCount);
                         pointMin = double.MaxValue;
                         pointMax = 0;
                         pointAvg = 0;
@@ -417,9 +436,7 @@ namespace BDInfo
                             pointSeconds += 1;
                         }
                         double pointMinutes = (pointSeconds - 1) / 60;
-                        pointsMin.Add(pointMinutes, pointMin);
-                        pointsAvg.Add(pointMinutes, pointAvg / pointCount);
-                        pointsMax.Add(pointMinutes, pointMax);
+                        AddAggregatePoint(pointsMin, pointsAvg, pointsMax, pointMinutes, pointMin, pointAvg, pointMax, pointCount);
                         pointMin = double.MaxValue;
                         pointMax = 0;
                         pointAvg = 0;


### PR DESCRIPTION
## Summary

- Guard chart aggregate points against empty buckets.
- Render sparse/empty chart intervals as zero instead of writing NaN or sentinel min values.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: chart rendering only; empty/sparse intervals now get zero-valued points.
- CLI impact: chart image export benefits from the same chart fix.
- Report format/backward compatibility impact: none; no report schema changes.

## Release Notes

- Fixed a chart edge case where sparse diagnostics could emit invalid aggregate values.
