### PR TITLE
Add local CLI smoke script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,7 @@ git diff --check
 For CLI/report/export changes, also run a real-disc smoke when a decrypted BD root is available, for example `V:\`:
 
 ```powershell
-$out = 'C:\dev\BDInfo_clicli\tmp_smoke_V'
-if (Test-Path $out) { Remove-Item -LiteralPath $out -Recurse -Force }
-New-Item -ItemType Directory -Path $out | Out-Null
-
-& .\BDInfo\bin\Release\BDInfo.exe V:\ $out --list
-& .\BDInfo\bin\Release\BDInfo.exe V:\ "$out\plain" -m 00016 -r txt,bdinfo,bdinfo-json --charts jpg
-& .\BDInfo\bin\Release\BDInfo.exe V:\ "$out\compressed" -m 00016 -r bdinfo,bdinfo-json --compress
+& .\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107 -ChartFormat jpg
 ```
 
 Clean temporary smoke output before committing.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Required checks before publishing a branch:
 - Visual Studio MSBuild Release build
 - `BDInfo.exe --help`
 - `.bdinfo` round-trip smoke: `.\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release`
-- Real-disc CLI smoke for CLI/report/chart changes
+- Real-disc CLI smoke for CLI/report/chart changes: `.\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107`
 - `.bdinfo` round-trip check for report serialization changes
 
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.

--- a/README_CLICLI.MD
+++ b/README_CLICLI.MD
@@ -92,7 +92,7 @@ Required checks before publishing a branch:
 - Visual Studio MSBuild Release build
 - `BDInfo.exe --help`
 - `.bdinfo` round-trip smoke: `.\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release`
-- Real-disc CLI smoke for CLI/report/chart changes
+- Real-disc CLI smoke for CLI/report/chart changes: `.\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107`
 - `.bdinfo` round-trip check for report serialization changes
 
 Codex/agent operating rules live in `AGENTS.md`. Pull requests should use the repository PR template.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,8 @@ Done when:
 
 ## 2. Add Shared Local Smoke Scripts
 
+Status: done.
+
 Goal: stop relying on copied command blocks for the `V:\` real-disc smoke.
 
 Scope:

--- a/scripts/smoke-local.ps1
+++ b/scripts/smoke-local.ps1
@@ -1,0 +1,123 @@
+param(
+    [string] $BuildOutputPath = (Join-Path $PSScriptRoot '..\BDInfo\bin\Release'),
+    [string] $SourcePath = 'V:\',
+    [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_local'),
+    [string] $Playlist = '00107',
+    [string] $PlainReportFormats = 'txt,bdinfo,bdinfo-json',
+    [string] $CompressedReportFormats = 'bdinfo,bdinfo-json',
+    [string] $ChartFormat = 'jpg',
+    [switch] $SkipCharts,
+    [switch] $KeepOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath([string] $Path) {
+    $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Invoke-BDInfo([string[]] $Arguments) {
+    Write-Host "BDInfo.exe $($Arguments -join ' ')"
+    & $script:ExePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "BDInfo.exe exited with code $LASTEXITCODE."
+    }
+}
+
+function Assert-DirectoryExists([string] $Path, [string] $Description) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "$Description was not created: $Path"
+    }
+}
+
+function Get-ExpectedReportPath([string] $Directory, [string] $Format, [bool] $Compressed) {
+    $pattern = switch ($Format) {
+        'txt' { '*.txt' }
+        'bdinfo' { if ($Compressed) { '*.bdinfo' } else { '*.bdinfo' } }
+        'bdinfo-json' { '*.json.bdinfo' }
+        default { throw "Unsupported report format in smoke script: $Format" }
+    }
+
+    $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
+
+    if ($Format -eq 'bdinfo') {
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+    }
+
+    $files | Select-Object -First 1
+}
+
+function Assert-ReportFormats([string] $Directory, [string] $Formats, [bool] $Compressed) {
+    Assert-DirectoryExists $Directory 'Report output directory'
+
+    foreach ($format in ($Formats -split ',' | ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ })) {
+        $file = Get-ExpectedReportPath $Directory $format $Compressed
+        if ($null -eq $file) {
+            throw "Expected $format report was not created in $Directory."
+        }
+
+        if ($Compressed -and $format -ne 'txt') {
+            $stream = [IO.File]::OpenRead($file.FullName)
+            try {
+                $first = $stream.ReadByte()
+                $second = $stream.ReadByte()
+                if ($first -ne [byte][char]'P' -or $second -ne [byte][char]'K') {
+                    throw "Expected compressed report is not a ZIP archive: $($file.FullName)"
+                }
+            }
+            finally {
+                $stream.Dispose()
+            }
+        }
+    }
+}
+
+$buildOutputFullPath = Resolve-FullPath $BuildOutputPath
+$outputFullPath = Resolve-FullPath $OutputPath
+$script:ExePath = Join-Path $buildOutputFullPath 'BDInfo.exe'
+
+if (-not (Test-Path -LiteralPath $script:ExePath -PathType Leaf)) {
+    throw "BDInfo.exe was not found at $script:ExePath. Build Release first or pass -BuildOutputPath."
+}
+
+if (-not (Test-Path -LiteralPath $SourcePath)) {
+    throw "Source path was not found: $SourcePath"
+}
+
+if (Test-Path -LiteralPath $outputFullPath) {
+    Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $outputFullPath | Out-Null
+
+try {
+    $plainOutput = Join-Path $outputFullPath 'plain'
+    $compressedOutput = Join-Path $outputFullPath 'compressed'
+
+    Invoke-BDInfo @($SourcePath, $outputFullPath, '--list')
+
+    $plainArgs = @($SourcePath, $plainOutput, '-m', $Playlist, '-r', $PlainReportFormats)
+    if (-not $SkipCharts) {
+        $plainArgs += @('--charts', $ChartFormat)
+    }
+    Invoke-BDInfo $plainArgs
+    Assert-ReportFormats $plainOutput $PlainReportFormats $false
+
+    if (-not $SkipCharts) {
+        $chartsOutput = Join-Path $plainOutput 'charts'
+        Assert-DirectoryExists $chartsOutput 'Charts output directory'
+        $chartFiles = Get-ChildItem -LiteralPath $chartsOutput -Filter "*.$ChartFormat" -File -ErrorAction SilentlyContinue
+        if (($chartFiles | Measure-Object).Count -lt 1) {
+            throw "No .$ChartFormat chart files were created in $chartsOutput."
+        }
+    }
+
+    Invoke-BDInfo @($SourcePath, $compressedOutput, '-m', $Playlist, '-r', $CompressedReportFormats, '--compress')
+    Assert-ReportFormats $compressedOutput $CompressedReportFormats $true
+
+    Write-Host "BDInfo local smoke passed: $outputFullPath"
+}
+finally {
+    if (-not $KeepOutput -and (Test-Path -LiteralPath $outputFullPath)) {
+        Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- Add `scripts/smoke-local.ps1` for the real-disc CLI smoke path.
- The script runs `--list`, plain text/XML/JSON report export with chart generation, and compressed XML/JSON report export.
- Replace the copied command block in `AGENTS.md` with the shared script and document it in both README files.
- Mark roadmap item 2 as done.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Local commands run:

- `./scripts/smoke-report-roundtrip.ps1 -BuildOutputPath ./BDInfo/bin/Release`
- `./scripts/smoke-local.ps1 -BuildOutputPath ./BDInfo/bin/Release -SourcePath V:\ -Playlist 00107 -ChartFormat jpg`

## Risk Notes

- GUI impact: none.
- CLI impact: no CLI behavior changes; the new script validates existing CLI behavior.
- Report format/backward compatibility impact: none.

## Release Notes

- Added a shared local smoke script for real-disc CLI/report/chart validation.
