### PR TITLE
Extract CLI argument parser

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -137,6 +137,7 @@
     <Compile Include="FormSettings.Designer.cs">
       <DependentUpon>FormSettings.cs</DependentUpon>
     </Compile>
+    <Compile Include="CliArgumentParser.cs" />
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="ConsoleWindow.cs" />
     <Compile Include="Program.cs" />

--- a/BDInfo/CliArgumentParser.cs
+++ b/BDInfo/CliArgumentParser.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace BDInfo
+{
+    internal enum ReportFormat
+    {
+        Text,
+        Bdinfo,
+        BdinfoJson
+    }
+
+    internal sealed class CliOptions
+    {
+        public string BdPath;
+        public string ReportDestination;
+        public bool ShowHelp;
+        public bool ShowVersion;
+        public bool ListPlaylists;
+        public bool WholeDisc;
+        public bool SaveCharts;
+        public string ChartFormat = "png";
+        public bool ReportFormatsSpecified;
+        public List<string> PlaylistNames { get; } = new List<string>();
+        public HashSet<ReportFormat> ReportFormats { get; } = new HashSet<ReportFormat> { ReportFormat.Text };
+        public bool CompressReports;
+    }
+
+    internal static class CliArgumentParser
+    {
+        public static bool ShouldHandle(string[] args)
+        {
+            bool hasOption = false;
+            int positionalCount = 0;
+
+            foreach (string arg in args)
+            {
+                if (string.IsNullOrWhiteSpace(arg))
+                {
+                    continue;
+                }
+
+                if (arg.StartsWith("-", StringComparison.Ordinal))
+                {
+                    hasOption = true;
+                }
+                else
+                {
+                    positionalCount++;
+                }
+            }
+
+            return hasOption || positionalCount > 1;
+        }
+
+        public static CliOptions Parse(string[] args)
+        {
+            var options = new CliOptions();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string arg = args[i];
+                if (string.IsNullOrWhiteSpace(arg))
+                {
+                    continue;
+                }
+
+                if (IsHelpOption(arg))
+                {
+                    options.ShowHelp = true;
+                    continue;
+                }
+
+                if (IsVersionOption(arg))
+                {
+                    options.ShowVersion = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-l", "--list"))
+                {
+                    options.ListPlaylists = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-w", "--whole"))
+                {
+                    options.WholeDisc = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-m", "--mpls", allowShortValue: true, allowLongValue: true))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-m", "--mpls");
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new ArgumentException("The --mpls option requires a comma separated list of playlists.");
+                    }
+                    options.PlaylistNames.AddRange(SplitValues(value));
+                    continue;
+                }
+
+                if (IsOption(arg, "-c", "--charts", allowLongValue: true))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-c", "--charts", allowMissingValue: true);
+                    options.SaveCharts = true;
+                    if (string.IsNullOrWhiteSpace(value) &&
+                        i + 1 < args.Length &&
+                        IsChartFormatName(args[i + 1]))
+                    {
+                        i++;
+                        value = args[i];
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(value))
+                    {
+                        options.ChartFormat = value;
+                    }
+                    continue;
+                }
+
+                if (IsOption(arg, "-z", "--compress"))
+                {
+                    options.CompressReports = true;
+                    continue;
+                }
+
+                if (IsOption(arg, "-r", "--report", allowShortValue: true, allowLongValue: true))
+                {
+                    string value = ExtractOptionValue(args, ref i, "-r", "--report");
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        throw new ArgumentException("The --report option requires a comma separated list of formats.");
+                    }
+
+                    if (!options.ReportFormatsSpecified)
+                    {
+                        options.ReportFormats.Clear();
+                    }
+
+                    bool anyFormat = false;
+                    foreach (string token in SplitValues(value))
+                    {
+                        options.ReportFormats.Add(ParseReportFormat(token));
+                        anyFormat = true;
+                    }
+
+                    if (!anyFormat)
+                    {
+                        throw new ArgumentException("The --report option did not include any formats.");
+                    }
+
+                    options.ReportFormatsSpecified = true;
+                    continue;
+                }
+
+                if (arg.StartsWith("-", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unknown option: {0}", arg));
+                }
+
+                if (string.IsNullOrEmpty(options.BdPath))
+                {
+                    options.BdPath = arg;
+                }
+                else if (string.IsNullOrEmpty(options.ReportDestination))
+                {
+                    options.ReportDestination = arg;
+                }
+                else
+                {
+                    throw new ArgumentException("Too many positional arguments supplied.");
+                }
+            }
+
+            return options;
+        }
+
+        private static bool IsHelpOption(string value)
+        {
+            return string.Equals(value, "-?", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsVersionOption(string value)
+        {
+            return string.Equals(value, "-v", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsOption(string value, string shortOption, string longOption, bool allowShortValue = false, bool allowLongValue = false)
+        {
+            if (string.Equals(value, shortOption, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, longOption, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(longOption)
+                && allowLongValue
+                && value.StartsWith(longOption + "=", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(shortOption)
+                && value.StartsWith(shortOption + "=", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(shortOption)
+                && shortOption.Length == 2
+                && allowShortValue
+                && value.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase)
+                && value.Length > shortOption.Length
+                && value[shortOption.Length] != '=')
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string ExtractOptionValue(string[] args, ref int index, string shortOption, string longOption, bool allowMissingValue = false)
+        {
+            string arg = args[index];
+
+            if (!string.IsNullOrEmpty(longOption) && arg.StartsWith(longOption, StringComparison.OrdinalIgnoreCase))
+            {
+                if (arg.Length == longOption.Length)
+                {
+                    if (allowMissingValue)
+                    {
+                        return null;
+                    }
+
+                    if (index + 1 >= args.Length)
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", longOption));
+                    }
+
+                    index++;
+                    return args[index];
+                }
+
+                if (arg[longOption.Length] == '=')
+                {
+                    return arg.Substring(longOption.Length + 1);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(shortOption) && arg.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase))
+            {
+                if (arg.Length == shortOption.Length)
+                {
+                    if (allowMissingValue)
+                    {
+                        return null;
+                    }
+
+                    if (index + 1 >= args.Length)
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", shortOption));
+                    }
+
+                    index++;
+                    return args[index];
+                }
+
+                if (arg[shortOption.Length] == '=')
+                {
+                    return arg.Substring(shortOption.Length + 1);
+                }
+
+                return arg.Substring(shortOption.Length);
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<string> SplitValues(string value)
+        {
+            return value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(v => v.Trim())
+                        .Where(v => v.Length > 0);
+        }
+
+        private static ReportFormat ParseReportFormat(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Report format value cannot be empty.");
+            }
+
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "txt":
+                case "text":
+                    return ReportFormat.Text;
+                case "bdinfo":
+                case "bdinfo-xml":
+                    return ReportFormat.Bdinfo;
+                case "bdinfo-json":
+                case "json":
+                    return ReportFormat.BdinfoJson;
+                default:
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported report format: {0}", value));
+            }
+        }
+
+        private static bool IsChartFormatName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            switch (name.Trim().ToLowerInvariant())
+            {
+                case "png":
+                case "jpg":
+                case "jpeg":
+                case "bmp":
+                case "gif":
+                case "tif":
+                case "tiff":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -22,29 +22,6 @@ namespace BDInfo
             "Video Frame Type Sizes"
         };
 
-        private enum ReportFormat
-        {
-            Text,
-            Bdinfo,
-            BdinfoJson
-        }
-
-        private sealed class CliOptions
-        {
-            public string BdPath;
-            public string ReportDestination;
-            public bool ShowHelp;
-            public bool ShowVersion;
-            public bool ListPlaylists;
-            public bool WholeDisc;
-            public bool SaveCharts;
-            public string ChartFormat = "png";
-            public bool ReportFormatsSpecified;
-            public List<string> PlaylistNames { get; } = new List<string>();
-            public HashSet<ReportFormat> ReportFormats { get; } = new HashSet<ReportFormat> { ReportFormat.Text };
-            public bool CompressReports;
-        }
-
         public static bool TryHandle(string[] args)
         {
             if (args == null || args.Length == 0)
@@ -52,7 +29,7 @@ namespace BDInfo
                 return false;
             }
 
-            if (!ShouldHandle(args))
+            if (!CliArgumentParser.ShouldHandle(args))
             {
                 return false;
             }
@@ -62,7 +39,7 @@ namespace BDInfo
                 CliOptions options;
                 try
                 {
-                    options = ParseArguments(args);
+                    options = CliArgumentParser.Parse(args);
                 }
                 catch (Exception ex)
                 {
@@ -104,265 +81,6 @@ namespace BDInfo
 
                 return true;
             }
-        }
-
-        private static bool ShouldHandle(string[] args)
-        {
-            bool hasOption = false;
-            int positionalCount = 0;
-
-            foreach (string arg in args)
-            {
-                if (string.IsNullOrWhiteSpace(arg))
-                {
-                    continue;
-                }
-
-                if (arg.StartsWith("-", StringComparison.Ordinal))
-                {
-                    hasOption = true;
-                }
-                else
-                {
-                    positionalCount++;
-                }
-            }
-
-            return hasOption || positionalCount > 1;
-        }
-
-        private static CliOptions ParseArguments(string[] args)
-        {
-            var options = new CliOptions();
-
-            for (int i = 0; i < args.Length; i++)
-            {
-                string arg = args[i];
-                if (string.IsNullOrWhiteSpace(arg))
-                {
-                    continue;
-                }
-
-                if (IsHelpOption(arg))
-                {
-                    options.ShowHelp = true;
-                    continue;
-                }
-
-                if (IsVersionOption(arg))
-                {
-                    options.ShowVersion = true;
-                    continue;
-                }
-
-                if (IsOption(arg, "-l", "--list"))
-                {
-                    options.ListPlaylists = true;
-                    continue;
-                }
-
-                if (IsOption(arg, "-w", "--whole"))
-                {
-                    options.WholeDisc = true;
-                    continue;
-                }
-
-                if (IsOption(arg, "-m", "--mpls", allowShortValue: true, allowLongValue: true))
-                {
-                    string value = ExtractOptionValue(args, ref i, "-m", "--mpls");
-                    if (string.IsNullOrWhiteSpace(value))
-                    {
-                        throw new ArgumentException("The --mpls option requires a comma separated list of playlists.");
-                    }
-                    options.PlaylistNames.AddRange(SplitValues(value));
-                    continue;
-                }
-
-                if (IsOption(arg, "-c", "--charts", allowLongValue: true))
-                {
-                    string value = ExtractOptionValue(args, ref i, "-c", "--charts", allowMissingValue: true);
-                    options.SaveCharts = true;
-                    if (string.IsNullOrWhiteSpace(value) &&
-                        i + 1 < args.Length &&
-                        IsChartFormatName(args[i + 1]))
-                    {
-                        i++;
-                        value = args[i];
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(value))
-                    {
-                        options.ChartFormat = value;
-                    }
-                    continue;
-                }
-
-                if (IsOption(arg, "-z", "--compress"))
-                {
-                    options.CompressReports = true;
-                    continue;
-                }
-
-                if (IsOption(arg, "-r", "--report", allowShortValue: true, allowLongValue: true))
-                {
-                    string value = ExtractOptionValue(args, ref i, "-r", "--report");
-                    if (string.IsNullOrWhiteSpace(value))
-                    {
-                        throw new ArgumentException("The --report option requires a comma separated list of formats.");
-                    }
-
-                    if (!options.ReportFormatsSpecified)
-                    {
-                        options.ReportFormats.Clear();
-                    }
-
-                    bool anyFormat = false;
-                    foreach (string token in SplitValues(value))
-                    {
-                        options.ReportFormats.Add(ParseReportFormat(token));
-                        anyFormat = true;
-                    }
-
-                    if (!anyFormat)
-                    {
-                        throw new ArgumentException("The --report option did not include any formats.");
-                    }
-
-                    options.ReportFormatsSpecified = true;
-                    continue;
-                }
-
-                if (arg.StartsWith("-", StringComparison.Ordinal))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unknown option: {0}", arg));
-                }
-
-                if (string.IsNullOrEmpty(options.BdPath))
-                {
-                    options.BdPath = arg;
-                }
-                else if (string.IsNullOrEmpty(options.ReportDestination))
-                {
-                    options.ReportDestination = arg;
-                }
-                else
-                {
-                    throw new ArgumentException("Too many positional arguments supplied.");
-                }
-            }
-
-            return options;
-        }
-
-        private static bool IsHelpOption(string value)
-        {
-            return string.Equals(value, "-?", StringComparison.OrdinalIgnoreCase)
-                   || string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
-                   || string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool IsVersionOption(string value)
-        {
-            return string.Equals(value, "-v", StringComparison.OrdinalIgnoreCase)
-                   || string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static bool IsOption(string value, string shortOption, string longOption, bool allowShortValue = false, bool allowLongValue = false)
-        {
-            if (string.Equals(value, shortOption, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(value, longOption, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (!string.IsNullOrEmpty(longOption)
-                && allowLongValue
-                && value.StartsWith(longOption + "=", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (!string.IsNullOrEmpty(shortOption)
-                && value.StartsWith(shortOption + "=", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (!string.IsNullOrEmpty(shortOption)
-                && shortOption.Length == 2
-                && allowShortValue
-                && value.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase)
-                && value.Length > shortOption.Length
-                && value[shortOption.Length] != '=')
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static string ExtractOptionValue(string[] args, ref int index, string shortOption, string longOption, bool allowMissingValue = false)
-        {
-            string arg = args[index];
-
-            if (!string.IsNullOrEmpty(longOption) && arg.StartsWith(longOption, StringComparison.OrdinalIgnoreCase))
-            {
-                if (arg.Length == longOption.Length)
-                {
-                    if (allowMissingValue)
-                    {
-                        return null;
-                    }
-
-                    if (index + 1 >= args.Length)
-                    {
-                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", longOption));
-                    }
-
-                    index++;
-                    return args[index];
-                }
-
-                if (arg[longOption.Length] == '=')
-                {
-                    return arg.Substring(longOption.Length + 1);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(shortOption) && arg.StartsWith(shortOption, StringComparison.OrdinalIgnoreCase))
-            {
-                if (arg.Length == shortOption.Length)
-                {
-                    if (allowMissingValue)
-                    {
-                        return null;
-                    }
-
-                    if (index + 1 >= args.Length)
-                    {
-                        throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Missing value for option {0}.", shortOption));
-                    }
-
-                    index++;
-                    return args[index];
-                }
-
-                if (arg[shortOption.Length] == '=')
-                {
-                    return arg.Substring(shortOption.Length + 1);
-                }
-
-                return arg.Substring(shortOption.Length);
-            }
-
-            return null;
-        }
-
-        private static IEnumerable<string> SplitValues(string value)
-        {
-            return value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                        .Select(v => v.Trim())
-                        .Where(v => v.Length > 0);
         }
 
         private static void Run(CliOptions options)
@@ -1621,29 +1339,6 @@ namespace BDInfo
             return writtenPaths;
         }
 
-        private static ReportFormat ParseReportFormat(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new ArgumentException("Report format value cannot be empty.");
-            }
-
-            switch (value.Trim().ToLowerInvariant())
-            {
-                case "txt":
-                case "text":
-                    return ReportFormat.Text;
-                case "bdinfo":
-                case "bdinfo-xml":
-                    return ReportFormat.Bdinfo;
-                case "bdinfo-json":
-                case "json":
-                    return ReportFormat.BdinfoJson;
-                default:
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported report format: {0}", value));
-            }
-        }
-
         private static int SaveCharts(IEnumerable<TSPlaylistFile> playlists, string directory, ImageFormat format, string extension)
         {
             Directory.CreateDirectory(directory);
@@ -1706,28 +1401,6 @@ namespace BDInfo
                     return (ImageFormat.Tiff, ".tiff");
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported chart image format: {0}", name));
-            }
-        }
-
-        private static bool IsChartFormatName(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return false;
-            }
-
-            switch (name.Trim().ToLowerInvariant())
-            {
-                case "png":
-                case "jpg":
-                case "jpeg":
-                case "bmp":
-                case "gif":
-                case "tif":
-                case "tiff":
-                    return true;
-                default:
-                    return false;
             }
         }
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,6 +72,8 @@ Done when:
 
 ## 5. Split and Harden CLI Internals
 
+Status: in progress.
+
 Goal: reduce risk in `ConsoleRunner.cs` without changing behavior.
 
 Scope:


### PR DESCRIPTION
## Summary

- Extract CLI option parsing from `ConsoleRunner` into `CliArgumentParser`.
- Move `CliOptions` and `ReportFormat` out of the runner so the execution path and parsing path are separated.
- Mark roadmap item 5 as in progress; remaining slices can focus on report naming and chart helpers.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Local commands run:

- `msbuild BDInfo.sln /p:Configuration=Release /p:Platform="Any CPU" /m`
- `./BDInfo/bin/Release/BDInfo.exe --help`
- `./BDInfo/bin/Release/BDInfo.exe --version`
- `./scripts/smoke-report-roundtrip.ps1 -BuildOutputPath ./BDInfo/bin/Release`
- Parser option smoke with `-m00107 -rbdinfo-json -c=jpg`
- Parser option smoke with `--mpls=00107 --report=bdinfo-json --charts=jpg`
- `./scripts/smoke-local.ps1 -BuildOutputPath ./BDInfo/bin/Release -SourcePath V:\ -Playlist 00107 -ChartFormat jpg`

## Risk Notes

- GUI impact: none intended.
- CLI impact: parser code moved; behavior should remain unchanged.
- Report format/backward compatibility impact: none.

## Release Notes

- Split CLI argument parsing out of the runner as the first CLI internals hardening step.
