### PR TITLE
Extract CLI report writer

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -138,6 +138,7 @@
       <DependentUpon>FormSettings.cs</DependentUpon>
     </Compile>
     <Compile Include="CliArgumentParser.cs" />
+    <Compile Include="CliReportWriter.cs" />
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="ConsoleWindow.cs" />
     <Compile Include="Program.cs" />

--- a/BDInfo/CliReportWriter.cs
+++ b/BDInfo/CliReportWriter.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using BDInfo.Reporting;
+
+namespace BDInfo
+{
+    internal static class CliReportWriter
+    {
+        public static List<string> WriteReports(
+            BDROM bdrom,
+            List<TSPlaylistFile> playlists,
+            ScanBDROMResult scanResult,
+            string destination,
+            IReadOnlyCollection<ReportFormat> formats,
+            bool compress)
+        {
+            if (formats == null || formats.Count == 0)
+            {
+                formats = new[] { ReportFormat.Text };
+            }
+
+            CliReportFileNames fileNames = CreateFileNames(bdrom.VolumeLabel, formats);
+            var writtenPaths = new List<string>();
+
+            if (formats.Contains(ReportFormat.Text))
+            {
+                using (var report = new FormReport())
+                {
+                    report.Generate(bdrom, playlists, scanResult);
+                    string reportText = report.ReportText;
+                    string reportPath = Path.Combine(destination, fileNames.TextFileName);
+                    File.WriteAllText(reportPath, reportText);
+                    writtenPaths.Add(reportPath);
+                }
+            }
+
+            if (formats.Contains(ReportFormat.BdinfoJson))
+            {
+                string jsonReportPath = Path.Combine(destination, fileNames.JsonReportFileName);
+                BDInfoReportSerializer.Save(jsonReportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json, compress);
+                writtenPaths.Add(jsonReportPath);
+            }
+
+            if (formats.Contains(ReportFormat.Bdinfo))
+            {
+                string reportPath = Path.Combine(destination, fileNames.XmlReportFileName);
+                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml, compress);
+                writtenPaths.Add(reportPath);
+            }
+
+            return writtenPaths;
+        }
+
+        internal static CliReportFileNames CreateFileNames(string volumeLabel, IReadOnlyCollection<ReportFormat> formats)
+        {
+            if (formats == null || formats.Count == 0)
+            {
+                formats = new[] { ReportFormat.Text };
+            }
+
+            string safeVolumeLabel = string.IsNullOrWhiteSpace(volumeLabel)
+                ? "UNKNOWN"
+                : volumeLabel;
+
+            string sanitizedVolumeLabel = ToolBox.GetSafeFileName(safeVolumeLabel);
+            if (string.IsNullOrWhiteSpace(sanitizedVolumeLabel))
+            {
+                sanitizedVolumeLabel = "BDINFO";
+            }
+
+            string textFileName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", sanitizedVolumeLabel));
+            string xmlFileName = sanitizedVolumeLabel + ".bdinfo";
+            string jsonFileName = formats.Contains(ReportFormat.Bdinfo)
+                ? sanitizedVolumeLabel + ".json.bdinfo"
+                : sanitizedVolumeLabel + ".bdinfo";
+
+            return new CliReportFileNames(textFileName, xmlFileName, jsonFileName);
+        }
+    }
+
+    internal sealed class CliReportFileNames
+    {
+        public CliReportFileNames(string textFileName, string xmlReportFileName, string jsonReportFileName)
+        {
+            TextFileName = textFileName;
+            XmlReportFileName = xmlReportFileName;
+            JsonReportFileName = jsonReportFileName;
+        }
+
+        public string TextFileName { get; private set; }
+        public string XmlReportFileName { get; private set; }
+        public string JsonReportFileName { get; private set; }
+    }
+}

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
-using BDInfo.Reporting;
 
 namespace BDInfo
 {
@@ -195,7 +194,7 @@ namespace BDInfo
                     options.ReportFormats.Add(ReportFormat.Text);
                 }
 
-                List<string> reportPaths = GenerateReports(
+                List<string> reportPaths = CliReportWriter.WriteReports(
                     bdrom,
                     selectedPlaylists,
                     scanResult,
@@ -1277,66 +1276,6 @@ namespace BDInfo
                 Report("Scan complete", _totalBytes);
                 Console.WriteLine();
             }
-        }
-
-        private static List<string> GenerateReports(
-            BDROM bdrom,
-            List<TSPlaylistFile> playlists,
-            ScanBDROMResult scanResult,
-            string destination,
-            IReadOnlyCollection<ReportFormat> formats,
-            bool compress)
-        {
-            if (formats == null || formats.Count == 0)
-            {
-                formats = new[] { ReportFormat.Text };
-            }
-
-            string volumeLabel = string.IsNullOrWhiteSpace(bdrom.VolumeLabel)
-                ? "UNKNOWN"
-                : bdrom.VolumeLabel;
-
-            string sanitizedVolumeLabel = ToolBox.GetSafeFileName(volumeLabel);
-            if (string.IsNullOrWhiteSpace(sanitizedVolumeLabel))
-            {
-                sanitizedVolumeLabel = "BDINFO";
-            }
-
-            string sanitizedTextName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", sanitizedVolumeLabel));
-            string sanitizedBaseName = sanitizedVolumeLabel;
-
-            var writtenPaths = new List<string>();
-
-            if (formats.Contains(ReportFormat.Text))
-            {
-                using (var report = new FormReport())
-                {
-                    report.Generate(bdrom, playlists, scanResult);
-                    string reportText = report.ReportText;
-                    string reportPath = Path.Combine(destination, sanitizedTextName);
-                    File.WriteAllText(reportPath, reportText);
-                    writtenPaths.Add(reportPath);
-                }
-            }
-
-            if (formats.Contains(ReportFormat.BdinfoJson))
-            {
-                string jsonFileName = formats.Contains(ReportFormat.Bdinfo)
-                    ? sanitizedBaseName + ".json.bdinfo"
-                    : sanitizedBaseName + ".bdinfo";
-                string jsonReportPath = Path.Combine(destination, jsonFileName);
-                BDInfoReportSerializer.Save(jsonReportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Json, compress);
-                writtenPaths.Add(jsonReportPath);
-            }
-
-            if (formats.Contains(ReportFormat.Bdinfo))
-            {
-                string reportPath = Path.Combine(destination, sanitizedBaseName + ".bdinfo");
-                BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml, compress);
-                writtenPaths.Add(reportPath);
-            }
-
-            return writtenPaths;
         }
 
         private static int SaveCharts(IEnumerable<TSPlaylistFile> playlists, string directory, ImageFormat format, string extension)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,6 +74,10 @@ Done when:
 
 Status: in progress.
 
+Progress:
+- Argument parsing is extracted into `CliArgumentParser`.
+- CLI report writing and output naming are extracted into `CliReportWriter`.
+
 Goal: reduce risk in `ConsoleRunner.cs` without changing behavior.
 
 Scope:


### PR DESCRIPTION
## Summary

- Extract CLI report generation and output filename selection from `ConsoleRunner` into `CliReportWriter`.
- Keep existing text, XML `.bdinfo`, JSON `.bdinfo`, combined XML+JSON, and compressed report filename behavior unchanged.
- Record item 5 roadmap progress without marking the item done yet.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] JSON-only report naming smoke
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: none intended; this moves CLI-only report writing code.
- CLI impact: no intended behavior change; existing report filenames and format handling are preserved.
- Report format/backward compatibility impact: XML, JSON, combined XML+JSON, and compressed `.bdinfo` outputs keep the existing naming rules.

## Release Notes

- Internal CLI report-writing logic was split out of `ConsoleRunner` for safer follow-up maintenance.
