### PR TITLE
Extract CLI chart format helper

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -138,6 +138,7 @@
       <DependentUpon>FormSettings.cs</DependentUpon>
     </Compile>
     <Compile Include="CliArgumentParser.cs" />
+    <Compile Include="CliChartFormat.cs" />
     <Compile Include="CliReportWriter.cs" />
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="ConsoleWindow.cs" />

--- a/BDInfo/CliArgumentParser.cs
+++ b/BDInfo/CliArgumentParser.cs
@@ -108,7 +108,7 @@ namespace BDInfo
                     options.SaveCharts = true;
                     if (string.IsNullOrWhiteSpace(value) &&
                         i + 1 < args.Length &&
-                        IsChartFormatName(args[i + 1]))
+                        CliChartFormat.IsKnownName(args[i + 1]))
                     {
                         i++;
                         value = args[i];
@@ -312,26 +312,5 @@ namespace BDInfo
             }
         }
 
-        private static bool IsChartFormatName(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return false;
-            }
-
-            switch (name.Trim().ToLowerInvariant())
-            {
-                case "png":
-                case "jpg":
-                case "jpeg":
-                case "bmp":
-                case "gif":
-                case "tif":
-                case "tiff":
-                    return true;
-                default:
-                    return false;
-            }
-        }
     }
 }

--- a/BDInfo/CliChartFormat.cs
+++ b/BDInfo/CliChartFormat.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Drawing.Imaging;
+using System.Globalization;
+
+namespace BDInfo
+{
+    internal static class CliChartFormat
+    {
+        public static CliChartImageFormat Resolve(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return new CliChartImageFormat(ImageFormat.Png, ".png");
+            }
+
+            CliChartImageFormat format;
+            if (TryResolve(name, out format))
+            {
+                return format;
+            }
+
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported chart image format: {0}", name));
+        }
+
+        public static bool IsKnownName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return false;
+            }
+
+            CliChartImageFormat unused;
+            return TryResolve(name, out unused);
+        }
+
+        private static bool TryResolve(string name, out CliChartImageFormat format)
+        {
+            switch (name.Trim().ToLowerInvariant())
+            {
+                case "png":
+                    format = new CliChartImageFormat(ImageFormat.Png, ".png");
+                    return true;
+                case "jpg":
+                case "jpeg":
+                    format = new CliChartImageFormat(ImageFormat.Jpeg, ".jpg");
+                    return true;
+                case "bmp":
+                    format = new CliChartImageFormat(ImageFormat.Bmp, ".bmp");
+                    return true;
+                case "gif":
+                    format = new CliChartImageFormat(ImageFormat.Gif, ".gif");
+                    return true;
+                case "tif":
+                case "tiff":
+                    format = new CliChartImageFormat(ImageFormat.Tiff, ".tiff");
+                    return true;
+                default:
+                    format = null;
+                    return false;
+            }
+        }
+    }
+
+    internal sealed class CliChartImageFormat
+    {
+        public CliChartImageFormat(ImageFormat imageFormat, string extension)
+        {
+            ImageFormat = imageFormat;
+            Extension = extension;
+        }
+
+        public ImageFormat ImageFormat { get; private set; }
+        public string Extension { get; private set; }
+    }
+}

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -100,8 +100,7 @@ namespace BDInfo
 
             bool requiresReportDestination = !options.ListPlaylists || NeedsFurtherProcessing(options);
             string reportDestination = null;
-            ImageFormat chartFormat = null;
-            string chartExtension = null;
+            CliChartImageFormat chartFormat = null;
 
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "BDInfo v{0}", GetVersionString()));
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Source: {0}", bdPath));
@@ -126,7 +125,7 @@ namespace BDInfo
 
                 if (options.SaveCharts)
                 {
-                    (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+                    chartFormat = CliChartFormat.Resolve(options.ChartFormat);
                 }
             }
 
@@ -208,13 +207,13 @@ namespace BDInfo
 
                 if (options.SaveCharts)
                 {
-                    if (chartFormat == null || string.IsNullOrEmpty(chartExtension))
+                    if (chartFormat == null)
                     {
-                        (chartFormat, chartExtension) = GetImageFormat(options.ChartFormat);
+                        chartFormat = CliChartFormat.Resolve(options.ChartFormat);
                     }
 
                     string chartsDirectory = Path.Combine(reportDestination, "charts");
-                    int chartsSaved = SaveCharts(selectedPlaylists, chartsDirectory, chartFormat, chartExtension);
+                    int chartsSaved = SaveCharts(selectedPlaylists, chartsDirectory, chartFormat.ImageFormat, chartFormat.Extension);
                     Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "Charts saved to: {0} ({1} files)", chartsDirectory, chartsSaved));
                 }
             }
@@ -1315,32 +1314,6 @@ namespace BDInfo
             }
 
             return savedCount;
-        }
-
-        private static (ImageFormat format, string extension) GetImageFormat(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return (ImageFormat.Png, ".png");
-            }
-
-            switch (name.Trim().ToLowerInvariant())
-            {
-                case "png":
-                    return (ImageFormat.Png, ".png");
-                case "jpg":
-                case "jpeg":
-                    return (ImageFormat.Jpeg, ".jpg");
-                case "bmp":
-                    return (ImageFormat.Bmp, ".bmp");
-                case "gif":
-                    return (ImageFormat.Gif, ".gif");
-                case "tif":
-                case "tiff":
-                    return (ImageFormat.Tiff, ".tiff");
-                default:
-                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unsupported chart image format: {0}", name));
-            }
         }
 
         private static string GetVersionString()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,11 +72,12 @@ Done when:
 
 ## 5. Split and Harden CLI Internals
 
-Status: in progress.
+Status: done.
 
 Progress:
 - Argument parsing is extracted into `CliArgumentParser`.
 - CLI report writing and output naming are extracted into `CliReportWriter`.
+- CLI chart format parsing and validation are extracted into `CliChartFormat`.
 
 Goal: reduce risk in `ConsoleRunner.cs` without changing behavior.
 


### PR DESCRIPTION
## Summary

- Extract CLI chart image format parsing and validation into `CliChartFormat`.
- Reuse the same helper from argument parsing and chart saving so supported names and aliases stay in sync.
- Mark roadmap item 5 as done now that parser, report writer, and chart format helpers are split out.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] Chart format smoke for `--charts jpg`, `--charts=jpeg`, default `--charts`, and invalid `--charts=webp`
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: none intended; this is CLI-only chart option plumbing.
- CLI impact: no intended behavior change for supported formats; `png`, `jpg`/`jpeg`, `bmp`, `gif`, and `tif`/`tiff` retain their existing output extensions.
- Report format/backward compatibility impact: none intended; report generation is unchanged.

## Release Notes

- Internal CLI chart format handling was centralized for safer follow-up maintenance.
