### PR TITLE
Extract GUI report export filename helper

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -144,6 +144,7 @@
     <Compile Include="ConsoleWindow.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReportFileNameHelper.cs" />
     <EmbeddedResource Include="FormChart.resx">
       <DependentUpon>FormChart.cs</DependentUpon>
     </EmbeddedResource>

--- a/BDInfo/CliReportWriter.cs
+++ b/BDInfo/CliReportWriter.cs
@@ -61,15 +61,7 @@ namespace BDInfo
                 formats = new[] { ReportFormat.Text };
             }
 
-            string safeVolumeLabel = string.IsNullOrWhiteSpace(volumeLabel)
-                ? "UNKNOWN"
-                : volumeLabel;
-
-            string sanitizedVolumeLabel = ToolBox.GetSafeFileName(safeVolumeLabel);
-            if (string.IsNullOrWhiteSpace(sanitizedVolumeLabel))
-            {
-                sanitizedVolumeLabel = "BDINFO";
-            }
+            string sanitizedVolumeLabel = ReportFileNameHelper.CreateSafeBaseName(volumeLabel, "UNKNOWN", "BDINFO");
 
             string textFileName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", sanitizedVolumeLabel));
             string xmlFileName = sanitizedVolumeLabel + ".bdinfo";

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1159,18 +1159,7 @@ namespace BDInfo
                 return;
             }
 
-            string defaultName = ReportBDROM.VolumeLabel;
-            if (string.IsNullOrWhiteSpace(defaultName))
-            {
-                defaultName = "BDINFO";
-            }
-
-            defaultName = ToolBox.GetSafeFileName(defaultName);
-            if (string.IsNullOrWhiteSpace(defaultName))
-            {
-                defaultName = "BDINFO";
-            }
-            defaultName += ".bdinfo";
+            string defaultName = ReportFileNameHelper.CreateGuiDefaultReportFileName(ReportBDROM.VolumeLabel);
 
             using (SaveFileDialog dialog = new SaveFileDialog())
             {

--- a/BDInfo/ReportFileNameHelper.cs
+++ b/BDInfo/ReportFileNameHelper.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace BDInfo
+{
+    internal static class ReportFileNameHelper
+    {
+        public static string CreateSafeBaseName(string volumeLabel, string emptyFallbackName, string unsafeFallbackName)
+        {
+            string baseName = string.IsNullOrWhiteSpace(volumeLabel)
+                ? emptyFallbackName
+                : volumeLabel;
+
+            baseName = ToolBox.GetSafeFileName(baseName);
+            if (string.IsNullOrWhiteSpace(baseName))
+            {
+                baseName = unsafeFallbackName;
+            }
+
+            return baseName;
+        }
+
+        public static string CreateGuiDefaultReportFileName(string volumeLabel)
+        {
+            return CreateSafeBaseName(volumeLabel, "BDINFO", "BDINFO") + ".bdinfo";
+        }
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,6 +95,11 @@ Done when:
 
 ## 6. Strengthen GUI Report Export and Load Coverage
 
+Status: in progress.
+
+Progress:
+- GUI report export default filename generation is extracted into `ReportFileNameHelper`.
+
 Goal: protect the GUI workflows that cannot be fully validated by CLI smoke.
 
 Scope:


### PR DESCRIPTION
## Summary

- Extract GUI report export default filename generation into `ReportFileNameHelper`.
- Reuse the same helper from CLI report naming while preserving the existing CLI fallback behavior: empty label -> `UNKNOWN`, unsafe sanitized label -> `BDINFO`.
- Mark roadmap item 6 as in progress with this first GUI export naming step.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] ReportFileNameHelper reflection smoke for empty, unsafe, and sanitized labels
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: the export dialog uses the same default `.bdinfo` filename behavior through a helper instead of inline code.
- CLI impact: no intended behavior change; existing report filenames and fallbacks are preserved.
- Report format/backward compatibility impact: none intended; serialization and file contents are unchanged.

## Release Notes

- GUI report export filename handling was moved into a non-UI helper for safer follow-up coverage.
