### PR TITLE
Extract GUI report loader

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -131,6 +131,7 @@
     <Compile Include="FormReport.Designer.cs">
       <DependentUpon>FormReport.cs</DependentUpon>
     </Compile>
+    <Compile Include="GuiReportLoader.cs" />
     <Compile Include="FormSettings.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/BDInfo/FormMain.cs
+++ b/BDInfo/FormMain.cs
@@ -28,7 +28,6 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
-using BDInfo.Reporting;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace BDInfo
@@ -402,7 +401,6 @@ namespace BDInfo
         private class InitBDROMResult
         {
             public Exception Exception;
-            public BDInfoReportData ReportData;
         }
 
         private void InitBDROM(
@@ -468,10 +466,10 @@ namespace BDInfo
 
                 if (isReport)
                 {
-                    BDInfoReportData reportData = BDInfoReportSerializer.Load(path);
-                    BDROM = BDInfoReportSerializer.CreateBDROM(reportData);
-                    ScanResult = BDInfoReportSerializer.CreateScanResult(reportData.ScanResult);
-                    e.Result = new InitBDROMResult { ReportData = reportData };
+                    GuiReportLoadResult reportLoadResult = GuiReportLoader.Load(path);
+                    BDROM = reportLoadResult.BDROM;
+                    ScanResult = reportLoadResult.ScanResult;
+                    e.Result = new InitBDROMResult();
                 }
                 else
                 {

--- a/BDInfo/GuiReportLoader.cs
+++ b/BDInfo/GuiReportLoader.cs
@@ -1,0 +1,40 @@
+using System;
+using BDInfo.Reporting;
+
+namespace BDInfo
+{
+    internal static class GuiReportLoader
+    {
+        public static GuiReportLoadResult Load(string path)
+        {
+            BDInfoReportData reportData = BDInfoReportSerializer.Load(path);
+            return FromReportData(reportData);
+        }
+
+        public static GuiReportLoadResult FromReportData(BDInfoReportData reportData)
+        {
+            if (reportData == null)
+            {
+                throw new ArgumentNullException(nameof(reportData));
+            }
+
+            BDROM bdrom = BDInfoReportSerializer.CreateBDROM(reportData);
+            ScanBDROMResult scanResult = BDInfoReportSerializer.CreateScanResult(reportData.ScanResult);
+            return new GuiReportLoadResult(bdrom, scanResult, reportData);
+        }
+    }
+
+    internal sealed class GuiReportLoadResult
+    {
+        public GuiReportLoadResult(BDROM bdrom, ScanBDROMResult scanResult, BDInfoReportData reportData)
+        {
+            BDROM = bdrom ?? throw new ArgumentNullException(nameof(bdrom));
+            ScanResult = scanResult ?? new ScanBDROMResult();
+            ReportData = reportData ?? throw new ArgumentNullException(nameof(reportData));
+        }
+
+        public BDROM BDROM { get; private set; }
+        public ScanBDROMResult ScanResult { get; private set; }
+        public BDInfoReportData ReportData { get; private set; }
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,6 +99,7 @@ Status: in progress.
 
 Progress:
 - GUI report export default filename generation is extracted into `ReportFileNameHelper`.
+- GUI `.bdinfo` load conversion is extracted into `GuiReportLoader`.
 
 Goal: protect the GUI workflows that cannot be fully validated by CLI smoke.
 


### PR DESCRIPTION
## Summary

- Extract GUI `.bdinfo` load conversion into `GuiReportLoader`.
- Keep `FormMain` responsible for UI state while the loader handles `BDInfoReportData` -> `BDROM`/`ScanBDROMResult` conversion.
- Record item 6 roadmap progress for GUI report loading coverage.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] GuiReportLoader reflection smoke for XML, JSON, and compressed `.bdinfo`
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: `.bdinfo` loading uses the same serializer/conversion calls through a helper; UI state handling is unchanged.
- CLI impact: none intended.
- Report format/backward compatibility impact: none intended; XML, JSON, and compressed report loading are preserved.

## Release Notes

- GUI report loading conversion was moved into a non-UI helper for safer follow-up coverage.
