### PR TITLE
Extract GUI report export selection

### DIFF
--- a/BDInfo/BDInfo.csproj
+++ b/BDInfo/BDInfo.csproj
@@ -131,6 +131,7 @@
     <Compile Include="FormReport.Designer.cs">
       <DependentUpon>FormReport.cs</DependentUpon>
     </Compile>
+    <Compile Include="GuiReportExportSelection.cs" />
     <Compile Include="GuiReportLoader.cs" />
     <Compile Include="FormSettings.cs">
       <SubType>Form</SubType>

--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1177,54 +1177,29 @@ namespace BDInfo
                 {
                     try
                     {
-                        bool compress = false;
-                        BDInfoReportFormat format = BDInfoReportFormat.Xml;
+                        GuiReportExportOptions exportOptions = GuiReportExportSelection.Create(dialog.FilterIndex, dialog.FileName);
 
-                        switch (dialog.FilterIndex)
+                        if (exportOptions.IsText)
                         {
-                            case 1:
-                                format = BDInfoReportFormat.Xml;
-                                break;
-                            case 2:
-                                format = BDInfoReportFormat.Json;
-                                break;
-                            case 3:
-                                format = BDInfoReportFormat.Xml;
-                                compress = true;
-                                break;
-                            case 4:
-                                format = BDInfoReportFormat.Json;
-                                compress = true;
-                                break;
-                            case 5:
-                                string textFileName = dialog.FileName;
-                                if (!string.Equals(Path.GetExtension(textFileName), ".txt", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    textFileName = Path.ChangeExtension(textFileName, ".txt");
-                                }
-
-                                using (var writer = new StreamWriter(textFileName, false, Encoding.UTF8))
-                                {
-                                    writer.Write(textBoxReport.Text);
-                                }
-                                MessageBox.Show(this,
-                                    "Report exported successfully.",
-                                    "BDInfo",
-                                    MessageBoxButtons.OK,
-                                    MessageBoxIcon.Information);
-                                return;
-                            default:
-                                format = BDInfoReportFormat.Xml;
-                                break;
+                            using (var writer = new StreamWriter(exportOptions.FileName, false, Encoding.UTF8))
+                            {
+                                writer.Write(textBoxReport.Text);
+                            }
+                            MessageBox.Show(this,
+                                "Report exported successfully.",
+                                "BDInfo",
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.Information);
+                            return;
                         }
 
                         BDInfoReportSerializer.Save(
-                            dialog.FileName,
+                            exportOptions.FileName,
                             ReportBDROM,
                             ReportPlaylists,
                             ReportScanResult,
-                            format,
-                            compress);
+                            exportOptions.Format,
+                            exportOptions.Compress);
                         MessageBox.Show(this,
                             "Report exported successfully.",
                             "BDInfo",

--- a/BDInfo/GuiReportExportSelection.cs
+++ b/BDInfo/GuiReportExportSelection.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using BDInfo.Reporting;
+
+namespace BDInfo
+{
+    internal static class GuiReportExportSelection
+    {
+        public static GuiReportExportOptions Create(int filterIndex, string fileName)
+        {
+            switch (filterIndex)
+            {
+                case 2:
+                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Json, compress: false);
+                case 3:
+                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Xml, compress: true);
+                case 4:
+                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Json, compress: true);
+                case 5:
+                    return GuiReportExportOptions.CreateText(GetTextFileName(fileName));
+                case 1:
+                default:
+                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Xml, compress: false);
+            }
+        }
+
+        private static string GetTextFileName(string fileName)
+        {
+            if (!string.Equals(Path.GetExtension(fileName), ".txt", StringComparison.OrdinalIgnoreCase))
+            {
+                return Path.ChangeExtension(fileName, ".txt");
+            }
+
+            return fileName;
+        }
+    }
+
+    internal sealed class GuiReportExportOptions
+    {
+        private GuiReportExportOptions()
+        {
+        }
+
+        public bool IsText { get; private set; }
+        public string FileName { get; private set; }
+        public BDInfoReportFormat Format { get; private set; }
+        public bool Compress { get; private set; }
+
+        public static GuiReportExportOptions CreateReport(string fileName, BDInfoReportFormat format, bool compress)
+        {
+            return new GuiReportExportOptions
+            {
+                IsText = false,
+                FileName = fileName,
+                Format = format,
+                Compress = compress
+            };
+        }
+
+        public static GuiReportExportOptions CreateText(string fileName)
+        {
+            return new GuiReportExportOptions
+            {
+                IsText = true,
+                FileName = fileName,
+                Format = BDInfoReportFormat.Xml,
+                Compress = false
+            };
+        }
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,6 +100,7 @@ Status: in progress.
 Progress:
 - GUI report export default filename generation is extracted into `ReportFileNameHelper`.
 - GUI `.bdinfo` load conversion is extracted into `GuiReportLoader`.
+- GUI report export format selection is extracted into `GuiReportExportSelection`.
 
 Goal: protect the GUI workflows that cannot be fully validated by CLI smoke.
 


### PR DESCRIPTION
## Summary

- Extract GUI report export `FilterIndex` handling into `GuiReportExportSelection`.
- Preserve existing GUI export behavior for XML, JSON, compressed XML, compressed JSON, text export, and default/all-files fallback.
- Record item 6 roadmap progress for GUI report export selection coverage.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] GuiReportExportSelection reflection smoke for filter indexes 1-6 and `.txt` extension handling
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: export dialog behavior is intended to be unchanged; format/compression/text filename selection now goes through a helper.
- CLI impact: none intended.
- Report format/backward compatibility impact: none intended; serializer calls still receive the same format/compress values.

## Release Notes

- GUI report export option handling was moved into a non-UI helper for safer coverage.
