### PR TITLE
Mark release readiness complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,6 +117,13 @@ Done when:
 
 ## 7. Release Readiness Pass
 
+Status: done.
+
+Progress:
+- Full local verification from `AGENTS.md` passed.
+- GitHub Actions is green on `UHD_Support`.
+- Release workflow created `v0.7.6.2-clicli.1` with `BDInfo_clicli.zip`.
+
 Goal: produce a clean tagged release only after the maintenance queue is stable.
 
 Scope:


### PR DESCRIPTION
## Summary

- Mark roadmap item 7 as done after completing the release readiness pass.
- Record that local verification passed, `UHD_Support` Actions is green, and release `v0.7.6.2-clicli.1` has `BDInfo_clicli.zip` attached.

## Verification

- [x] `git diff --check`
- [ ] Visual Studio MSBuild Release build
- [ ] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

Documentation-only change. The full release verification already passed before tag push, and GitHub Actions will run for this PR.

## Risk Notes

- GUI impact: none; documentation only.
- CLI impact: none; documentation only.
- Report format/backward compatibility impact: none; documentation only.

## Release Notes

- Roadmap now records completion of the `v0.7.6.2-clicli.1` release readiness pass.
