### PR TITLE
Add HDR10+ carryover smoke

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,10 @@ jobs:
         shell: pwsh
         run: .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\dist
 
+      - name: Smoke test HDR10+ carryover reset
+        shell: pwsh
+        run: .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\dist
+
       - name: Verify build output
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ git diff --check
 & 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
 & .\BDInfo\bin\Release\BDInfo.exe --help
 & .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release
+& .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
 ```
 
 For CLI/report/export changes, also run a real-disc smoke when a decrypted BD root is available, for example `V:\`:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Required checks before publishing a branch:
 - Visual Studio MSBuild Release build
 - `BDInfo.exe --help`
 - `.bdinfo` round-trip smoke: `.\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release`
+- HDR10+ carryover smoke: `.\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release`
 - Real-disc CLI smoke for CLI/report/chart changes: `.\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107`
 - `.bdinfo` round-trip check for report serialization changes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,11 @@ These items should be handled after `v0.7.6.2-clicli.1`, one small PR at a time.
 
 ### 8. Recheck HDR10+ Carryover Fix
 
+Status: in progress.
+
+Progress:
+- Added an automated smoke that verifies a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
+
 Goal: verify that the documented HDR10+ carryover fix still behaves correctly after the report/export/load refactors.
 
 Scope:

--- a/scripts/smoke-hdr10plus-carryover.ps1
+++ b/scripts/smoke-hdr10plus-carryover.ps1
@@ -1,0 +1,54 @@
+param(
+    [string] $BuildOutputPath = (Join-Path $PSScriptRoot '..\BDInfo\bin\Release')
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath([string] $Path) {
+    $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Assert-True([bool] $Condition, [string] $Message) {
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Invoke-HevcScan($Stream) {
+    $buffer = New-Object BDInfo.TSStreamBuffer
+    $buffer.BeginRead()
+    $tag = $null
+    [BDInfo.TSCodecHEVC]::Scan($Stream, $buffer, [ref] $tag)
+}
+
+$buildOutputFullPath = Resolve-FullPath $BuildOutputPath
+$exePath = Join-Path $buildOutputFullPath 'BDInfo.exe'
+
+if (-not (Test-Path -LiteralPath $exePath)) {
+    throw "BDInfo.exe was not found at $exePath. Build the Release configuration first or pass -BuildOutputPath."
+}
+
+Get-ChildItem -LiteralPath $buildOutputFullPath -Filter '*.dll' | ForEach-Object {
+    [Reflection.Assembly]::LoadFrom($_.FullName) | Out-Null
+}
+[Reflection.Assembly]::LoadFrom($exePath) | Out-Null
+
+$hdrData = New-Object 'BDInfo.TSCodecHEVC+ExtendedDataSet'
+$hdrData.IsHdr10Plus = $true
+$hdrStream = New-Object BDInfo.TSVideoStream
+$hdrStream.StreamType = [BDInfo.TSStreamType]::HEVC_VIDEO
+$hdrStream.ExtendedData = $hdrData
+
+Invoke-HevcScan $hdrStream
+Assert-True $hdrStream.ExtendedData.IsHdr10Plus 'HDR10+ source stream did not preserve its HDR10+ state.'
+Assert-True ([BDInfo.TSCodecHEVC]::IsHdr10Plus) 'HDR10+ static state was not set by the HDR10+ source stream.'
+
+$nonHdrStream = New-Object BDInfo.TSVideoStream
+$nonHdrStream.StreamType = [BDInfo.TSStreamType]::HEVC_VIDEO
+
+Invoke-HevcScan $nonHdrStream
+Assert-True ($null -ne $nonHdrStream.ExtendedData) 'Fresh HEVC stream did not receive HEVC extended data.'
+Assert-True (-not $nonHdrStream.ExtendedData.IsHdr10Plus) 'Fresh HEVC stream inherited HDR10+ state from a previous stream.'
+Assert-True (-not [BDInfo.TSCodecHEVC]::IsHdr10Plus) 'HEVC static HDR10+ state was not reset for a fresh non-HDR10+ stream.'
+
+Write-Host 'HDR10+ carryover smoke passed.'


### PR DESCRIPTION
## Summary

- Add `scripts/smoke-hdr10plus-carryover.ps1` to verify a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
- Run the new HDR10+ carryover smoke in GitHub Actions after the report round-trip smoke.
- Document the new required smoke in `AGENTS.md` and `README.md`.
- Mark roadmap item 8 as in progress with the automated check now added.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] `BDInfo.exe --version`
- [x] `scripts/smoke-hdr10plus-carryover.ps1`
- [x] Real-disc CLI smoke with `V:\`, playlist `00107`, and `--charts jpg`
- [x] Exported `.bdinfo` round-trip checked with `scripts/smoke-report-roundtrip.ps1`

## Risk Notes

- GUI impact: none intended; this adds an automated smoke for HEVC metadata state.
- CLI impact: none intended, except CI now runs one additional quick smoke script.
- Report format/backward compatibility impact: none intended.

## Release Notes

- Added an automated HDR10+ carryover smoke check to guard against HEVC metadata state leaking between streams.
