### PR TITLE
[codex] Add HDR10+ real-disc smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ For CLI/report/export changes, also run a real-disc smoke when a decrypted BD ro
 & .\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107 -ChartFormat jpg
 ```
 
+For HDR10+ scanner changes, also run a real HDR10+ disc smoke when sample media is available:
+
+```powershell
+& .\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800 -ChartFormat jpg
+```
+
 Clean temporary smoke output before committing.
 
 ## Review Checklist

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Required checks before publishing a branch:
 - `.bdinfo` round-trip smoke: `.\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release`
 - HDR10+ carryover smoke: `.\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release`
 - Real-disc CLI smoke for CLI/report/chart changes: `.\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00107`
+- Real-disc HDR10+ smoke when sample media is available: `.\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800`
 - `.bdinfo` round-trip check for report serialization changes
 
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,6 +147,7 @@ Status: in progress.
 
 Progress:
 - Added an automated smoke that verifies a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
+- Added a local real-disc HDR10+ smoke script for sample media and verified `V:\` / `00800.MPLS` exports `HDR10+` in text, XML `.bdinfo`, and JSON `.bdinfo` reports with charts.
 
 Goal: verify that the documented HDR10+ carryover fix still behaves correctly after the report/export/load refactors.
 

--- a/scripts/smoke-hdr10plus-local.ps1
+++ b/scripts/smoke-hdr10plus-local.ps1
@@ -1,0 +1,116 @@
+param(
+    [string] $BuildOutputPath = (Join-Path $PSScriptRoot '..\BDInfo\bin\Release'),
+    [string] $SourcePath = 'V:\',
+    [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_hdr10plus_local'),
+    [string] $Playlist = '00800',
+    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
+    [string] $ChartFormat = 'jpg',
+    [switch] $SkipCharts,
+    [switch] $KeepOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath([string] $Path) {
+    $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Invoke-BDInfo([string[]] $Arguments) {
+    Write-Host "BDInfo.exe $($Arguments -join ' ')"
+    & $script:ExePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "BDInfo.exe exited with code $LASTEXITCODE."
+    }
+}
+
+function Assert-DirectoryExists([string] $Path, [string] $Description) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "$Description was not created: $Path"
+    }
+}
+
+function Assert-FileContainsHdr10Plus([string] $Path, [string] $Description) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Description was not created: $Path"
+    }
+
+    if ((Get-Content -LiteralPath $Path -Raw) -notmatch 'HDR10\+') {
+        throw "$Description does not contain HDR10+: $Path"
+    }
+}
+
+function Get-ReportFile([string] $Directory, [string] $Format) {
+    $pattern = switch ($Format) {
+        'txt' { '*.txt' }
+        'bdinfo' { '*.bdinfo' }
+        'bdinfo-json' { '*.json.bdinfo' }
+        default { throw "Unsupported report format in smoke script: $Format" }
+    }
+
+    $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
+
+    if ($Format -eq 'bdinfo') {
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+    }
+
+    $files | Select-Object -First 1
+}
+
+function Assert-Hdr10PlusReports([string] $Directory, [string] $Formats) {
+    Assert-DirectoryExists $Directory 'Report output directory'
+
+    foreach ($format in ($Formats -split ',' | ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ })) {
+        $file = Get-ReportFile $Directory $format
+        if ($null -eq $file) {
+            throw "Expected $format report was not created in $Directory."
+        }
+
+        Assert-FileContainsHdr10Plus $file.FullName "$format report"
+    }
+}
+
+$buildOutputFullPath = Resolve-FullPath $BuildOutputPath
+$outputFullPath = Resolve-FullPath $OutputPath
+$script:ExePath = Join-Path $buildOutputFullPath 'BDInfo.exe'
+
+if (-not (Test-Path -LiteralPath $script:ExePath -PathType Leaf)) {
+    throw "BDInfo.exe was not found at $script:ExePath. Build Release first or pass -BuildOutputPath."
+}
+
+if (-not (Test-Path -LiteralPath $SourcePath)) {
+    throw "Source path was not found: $SourcePath"
+}
+
+if (Test-Path -LiteralPath $outputFullPath) {
+    Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $outputFullPath | Out-Null
+
+try {
+    $reportOutput = Join-Path $outputFullPath 'report'
+
+    Invoke-BDInfo @($SourcePath, $outputFullPath, '--list')
+
+    $reportArgs = @($SourcePath, $reportOutput, '-m', $Playlist, '-r', $ReportFormats)
+    if (-not $SkipCharts) {
+        $reportArgs += @('--charts', $ChartFormat)
+    }
+    Invoke-BDInfo $reportArgs
+    Assert-Hdr10PlusReports $reportOutput $ReportFormats
+
+    if (-not $SkipCharts) {
+        $chartsOutput = Join-Path $reportOutput 'charts'
+        Assert-DirectoryExists $chartsOutput 'Charts output directory'
+        $chartFiles = Get-ChildItem -LiteralPath $chartsOutput -Filter "*.$ChartFormat" -File -ErrorAction SilentlyContinue
+        if (($chartFiles | Measure-Object).Count -lt 1) {
+            throw "No .$ChartFormat chart files were created in $chartsOutput."
+        }
+    }
+
+    Write-Host "BDInfo HDR10+ local smoke passed: $outputFullPath"
+}
+finally {
+    if (-not $KeepOutput -and (Test-Path -LiteralPath $outputFullPath)) {
+        Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- add an optional real-disc HDR10+ smoke script for sample media such as `V:\` / `00800.MPLS`
- document when to run the HDR10+ real-disc smoke in `AGENTS.md` and `README.md`
- record the successful `V:\` / `00800.MPLS` verification in `ROADMAP.md`

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`
- [x] `scripts/smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800 -ChartFormat jpg`

## Risk Notes

- GUI impact: none expected; docs/script only.
- CLI impact: no CLI behavior change; the new smoke exercises existing CLI exports.
- Report format/backward compatibility impact: none expected; the smoke checks existing txt/XML/JSON `.bdinfo` output contains `HDR10+`.

## Release Notes

- Added an optional local HDR10+ disc smoke script for scanner verification when sample media is available.