### PR TITLE
[codex] Document HDR10+ manual swap verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@ For HDR10+ scanner changes, also run a real HDR10+ disc smoke when sample media 
 & .\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800 -ChartFormat jpg
 ```
 
+When verifying the HDR10+ carryover bug with manual disc swapping, keep BDInfo running in the same process:
+
+1. Open the GUI and scan an HDR10+ title, for example `V:\` / `00800.MPLS`.
+2. Confirm the first report shows `HDR10+`.
+3. Without closing BDInfo, swap to a non-HDR10+ disc and scan a known non-HDR10+ playlist.
+4. Export the second report and confirm it does not contain `HDR10+`.
+5. Record both disc/playlist IDs in the PR notes.
+
 Clean temporary smoke output before committing.
 
 ## Review Checklist

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Required checks before publishing a branch:
 - Real-disc HDR10+ smoke when sample media is available: `.\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800`
 - `.bdinfo` round-trip check for report serialization changes
 
+Manual HDR10+ carryover verification requires one BDInfo process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing BDInfo, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`.
+
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,6 +155,7 @@ Scope:
 - Find the exact stream metadata path that sets and clears HDR10+ state.
 - Reproduce the original carryover scenario when possible: scan or load an HDR10+ title, then scan or load a non-HDR10+ title in the same process.
 - Check both direct disc scan and saved `.bdinfo` load paths if suitable sample material is available.
+- For manual disc swapping, keep one BDInfo process open: scan HDR10+ `V:\` / `00800.MPLS`, swap to a known non-HDR10+ disc, scan its playlist, export the second report, and confirm `HDR10+` is absent.
 - Add a narrow automated check if the behavior can be represented without copyrighted sample media; otherwise document the manual verification steps.
 
 Done when:


### PR DESCRIPTION
## Summary

- document the required same-process manual flow for HDR10+ carryover testing with disc swapping
- add the manual check to `AGENTS.md`, `README.md`, and the post-release roadmap

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [ ] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: no code change; documents a GUI manual verification path.
- CLI impact: none.
- Report format/backward compatibility impact: none.

## Release Notes

- Documented the same-process manual HDR10+ carryover verification flow for disc swaps.