### PR TITLE
[codex] Add HDR10+ swap smoke script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,12 @@ When verifying the HDR10+ carryover bug with manual disc swapping, keep BDInfo r
 4. Export the second report and confirm it does not contain `HDR10+`.
 5. Record both disc/playlist IDs in the PR notes.
 
+The same-process swap can also be checked through the local PowerShell smoke. This script loads `BDInfo.exe` once and runs both scans through `ConsoleRunner` in that same PowerShell process:
+
+```powershell
+& .\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap
+```
+
 Clean temporary smoke output before committing.
 
 ## Review Checklist

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Required checks before publishing a branch:
 - Real-disc HDR10+ smoke when sample media is available: `.\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800`
 - `.bdinfo` round-trip check for report serialization changes
 
-Manual HDR10+ carryover verification requires one BDInfo process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing BDInfo, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`.
+Manual HDR10+ carryover verification requires one process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing the process, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`. The same-process CLI path can be checked with `.\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap`.
 
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,6 +148,7 @@ Status: in progress.
 Progress:
 - Added an automated smoke that verifies a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
 - Added a local real-disc HDR10+ smoke script for sample media and verified `V:\` / `00800.MPLS` exports `HDR10+` in text, XML `.bdinfo`, and JSON `.bdinfo` reports with charts.
+- Added a same-process local swap smoke that scans HDR10+ media, pauses for a manual non-HDR10+ disc swap, then checks that the second report does not contain `HDR10+`.
 
 Goal: verify that the documented HDR10+ carryover fix still behaves correctly after the report/export/load refactors.
 

--- a/scripts/smoke-hdr10plus-swap-local.ps1
+++ b/scripts/smoke-hdr10plus-swap-local.ps1
@@ -1,0 +1,164 @@
+param(
+    [string] $BuildOutputPath = (Join-Path $PSScriptRoot '..\BDInfo\bin\Release'),
+    [string] $FirstSourcePath = 'V:\',
+    [string] $SecondSourcePath = 'V:\',
+    [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_hdr10plus_swap'),
+    [string] $FirstPlaylist = '00800',
+    [string] $SecondPlaylist,
+    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
+    [switch] $SelfTest,
+    [switch] $WaitForDiscSwap,
+    [switch] $KeepOutput
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath([string] $Path) {
+    $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Invoke-BDInfoInProcess([string[]] $Arguments) {
+    Write-Host "BDInfo.exe $($Arguments -join ' ')"
+    [Environment]::ExitCode = 0
+    $handled = $script:TryHandle.Invoke($null, [object[]] @(, $Arguments))
+
+    if (-not $handled) {
+        throw 'BDInfo ConsoleRunner did not handle the supplied arguments.'
+    }
+
+    if ([Environment]::ExitCode -ne 0) {
+        throw "BDInfo.exe exited with code $([Environment]::ExitCode)."
+    }
+}
+
+function Assert-DirectoryExists([string] $Path, [string] $Description) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "$Description was not created: $Path"
+    }
+}
+
+function Test-FileContainsHdr10Plus([string] $Path) {
+    $match = Select-String -LiteralPath $Path -SimpleMatch 'HDR10+' -List -ErrorAction SilentlyContinue
+    $null -ne $match
+}
+
+function Get-ReportFile([string] $Directory, [string] $Format) {
+    $pattern = switch ($Format) {
+        'txt' { '*.txt' }
+        'bdinfo' { '*.bdinfo' }
+        'bdinfo-json' { '*.json.bdinfo' }
+        default { throw "Unsupported report format in smoke script: $Format" }
+    }
+
+    $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
+
+    if ($Format -eq 'bdinfo') {
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+    }
+
+    $files | Select-Object -First 1
+}
+
+function Get-ReportFiles([string] $Directory, [string] $Formats) {
+    Assert-DirectoryExists $Directory 'Report output directory'
+
+    $reportFiles = New-Object 'System.Collections.Generic.List[System.IO.FileInfo]'
+    foreach ($format in ($Formats -split ',' | ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ })) {
+        $file = Get-ReportFile $Directory $format
+        if ($null -eq $file) {
+            throw "Expected $format report was not created in $Directory."
+        }
+
+        $reportFiles.Add($file)
+    }
+
+    $reportFiles
+}
+
+function Assert-ReportsContainHdr10Plus([string] $Directory, [string] $Formats) {
+    foreach ($file in (Get-ReportFiles $Directory $Formats)) {
+        if (-not (Test-FileContainsHdr10Plus $file.FullName)) {
+            throw "Expected HDR10+ in report: $($file.FullName)"
+        }
+    }
+}
+
+function Assert-ReportsDoNotContainHdr10Plus([string] $Directory, [string] $Formats) {
+    foreach ($file in (Get-ReportFiles $Directory $Formats)) {
+        if (Test-FileContainsHdr10Plus $file.FullName) {
+            throw "Unexpected HDR10+ carryover in report: $($file.FullName)"
+        }
+    }
+}
+
+$buildOutputFullPath = Resolve-FullPath $BuildOutputPath
+$outputFullPath = Resolve-FullPath $OutputPath
+$exePath = Join-Path $buildOutputFullPath 'BDInfo.exe'
+
+if (-not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+    throw "BDInfo.exe was not found at $exePath. Build Release first or pass -BuildOutputPath."
+}
+
+Get-ChildItem -LiteralPath $buildOutputFullPath -Filter '*.dll' | ForEach-Object {
+    [Reflection.Assembly]::LoadFrom($_.FullName) | Out-Null
+}
+$assembly = [Reflection.Assembly]::LoadFrom($exePath)
+$consoleRunner = $assembly.GetType('BDInfo.ConsoleRunner', $true)
+$script:TryHandle = $consoleRunner.GetMethod('TryHandle', [Reflection.BindingFlags] 'Public,Static')
+if ($null -eq $script:TryHandle) {
+    throw 'BDInfo.ConsoleRunner.TryHandle was not found.'
+}
+
+if ($SelfTest) {
+    Invoke-BDInfoInProcess @('--help')
+    Write-Host 'BDInfo HDR10+ swap smoke self-test passed.'
+    return
+}
+
+if (-not (Test-Path -LiteralPath $FirstSourcePath)) {
+    throw "First source path was not found: $FirstSourcePath"
+}
+
+if (Test-Path -LiteralPath $outputFullPath) {
+    Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $outputFullPath | Out-Null
+
+try {
+    $firstOutput = Join-Path $outputFullPath 'first-hdr10plus'
+    $secondOutput = Join-Path $outputFullPath 'second-non-hdr10plus'
+
+    Invoke-BDInfoInProcess @($FirstSourcePath, $outputFullPath, '--list')
+    Invoke-BDInfoInProcess @($FirstSourcePath, $firstOutput, '-m', $FirstPlaylist, '-r', $ReportFormats)
+    Assert-ReportsContainHdr10Plus $firstOutput $ReportFormats
+
+    if ($WaitForDiscSwap) {
+        Write-Host ''
+        Write-Host 'Swap to a known non-HDR10+ disc without closing this PowerShell process.'
+        if ([string]::IsNullOrWhiteSpace($SecondPlaylist)) {
+            $SecondPlaylist = Read-Host 'Enter the non-HDR10+ playlist number, for example 00107'
+        }
+        else {
+            Read-Host "Press Enter after the non-HDR10+ disc is ready at $SecondSourcePath"
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($SecondPlaylist)) {
+        throw 'SecondPlaylist is required. Pass -SecondPlaylist or use -WaitForDiscSwap to enter it interactively.'
+    }
+
+    if (-not (Test-Path -LiteralPath $SecondSourcePath)) {
+        throw "Second source path was not found: $SecondSourcePath"
+    }
+
+    Invoke-BDInfoInProcess @($SecondSourcePath, $outputFullPath, '--list')
+    Invoke-BDInfoInProcess @($SecondSourcePath, $secondOutput, '-m', $SecondPlaylist, '-r', $ReportFormats)
+    Assert-ReportsDoNotContainHdr10Plus $secondOutput $ReportFormats
+
+    Write-Host "BDInfo HDR10+ swap smoke passed: $outputFullPath"
+}
+finally {
+    if (-not $KeepOutput -and (Test-Path -LiteralPath $outputFullPath)) {
+        Remove-Item -LiteralPath $outputFullPath -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- add `scripts/smoke-hdr10plus-swap-local.ps1` for same-process HDR10+ carryover verification with manual disc swapping
- invoke `BDInfo.ConsoleRunner.TryHandle(...)` through reflection so both scans run in one PowerShell process
- document the script in `AGENTS.md`, `README.md`, and `ROADMAP.md`

## Verification

- [x] PowerShell parser check for `scripts/smoke-hdr10plus-swap-local.ps1`
- [x] `scripts/smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SelfTest`
- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`

## Risk Notes

- GUI impact: none; this adds a local verification script.
- CLI impact: no CLI behavior change; the script calls the existing CLI runner in-process.
- Report format/backward compatibility impact: none; it checks existing txt/XML/JSON `.bdinfo` output.

Manual follow-up: full `-WaitForDiscSwap` mode still needs a known non-HDR10+ disc and playlist after the first HDR10+ scan.

## Release Notes

- Added a local same-process HDR10+ swap smoke script for manual disc-swap verification.