### PR TITLE
[codex] Add synthetic HDR10+ real non-HDR smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ The same-process swap can also be checked through the local PowerShell smoke. Th
 & .\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap
 ```
 
+When only a non-HDR10+ disc is available, use the synthetic-first mode to seed HDR10+ state before scanning the real disc in the same process:
+
+```powershell
+& .\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001
+```
+
 Clean temporary smoke output before committing.
 
 If report fixture models change intentionally, regenerate the synthetic committed fixtures with:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Required checks before publishing a branch:
 - Real-disc HDR10+ smoke when sample media is available: `.\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800`
 - `.bdinfo` round-trip check for report serialization changes
 
-Manual HDR10+ carryover verification requires one process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing the process, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`. The same-process CLI path can be checked with `.\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap`.
+Manual HDR10+ carryover verification requires one process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing the process, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`. The same-process CLI path can be checked with `.\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap`; when only a non-HDR10+ disc is available, use `-SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001`.
 
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,6 +149,7 @@ Progress:
 - Added an automated smoke that verifies a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
 - Added a local real-disc HDR10+ smoke script for sample media and verified `V:\` / `00800.MPLS` exports `HDR10+` in text, XML `.bdinfo`, and JSON `.bdinfo` reports with charts.
 - Added a same-process local swap smoke that scans HDR10+ media, pauses for a manual non-HDR10+ disc swap, then checks that the second report does not contain `HDR10+`.
+- Added a synthetic-first same-process mode and verified it against a real non-HDR10+ disc at `V:\` / `00001.MPLS`; the second text, XML `.bdinfo`, and JSON `.bdinfo` reports did not contain `HDR10+`.
 
 Goal: verify that the documented HDR10+ carryover fix still behaves correctly after the report/export/load refactors.
 

--- a/scripts/smoke-hdr10plus-swap-local.ps1
+++ b/scripts/smoke-hdr10plus-swap-local.ps1
@@ -7,6 +7,7 @@ param(
     [string] $SecondPlaylist,
     [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
     [switch] $SelfTest,
+    [switch] $SyntheticFirst,
     [switch] $WaitForDiscSwap,
     [switch] $KeepOutput
 )
@@ -29,6 +30,28 @@ function Invoke-BDInfoInProcess([string[]] $Arguments) {
     if ([Environment]::ExitCode -ne 0) {
         throw "BDInfo.exe exited with code $([Environment]::ExitCode)."
     }
+}
+
+function Invoke-HevcScan($Stream) {
+    $buffer = New-Object BDInfo.TSStreamBuffer
+    $buffer.BeginRead()
+    $tag = $null
+    [BDInfo.TSCodecHEVC]::Scan($Stream, $buffer, [ref] $tag)
+}
+
+function Set-SyntheticHdr10PlusState {
+    $hdrData = New-Object 'BDInfo.TSCodecHEVC+ExtendedDataSet'
+    $hdrData.IsHdr10Plus = $true
+    $hdrStream = New-Object BDInfo.TSVideoStream
+    $hdrStream.StreamType = [BDInfo.TSStreamType]::HEVC_VIDEO
+    $hdrStream.ExtendedData = $hdrData
+
+    Invoke-HevcScan $hdrStream
+    if (-not [BDInfo.TSCodecHEVC]::IsHdr10Plus) {
+        throw 'Synthetic HDR10+ scan did not set TSCodecHEVC.IsHdr10Plus.'
+    }
+
+    Write-Host 'Synthetic HDR10+ state set in current process.'
 }
 
 function Assert-DirectoryExists([string] $Path, [string] $Description) {
@@ -115,7 +138,7 @@ if ($SelfTest) {
     return
 }
 
-if (-not (Test-Path -LiteralPath $FirstSourcePath)) {
+if (-not $SyntheticFirst -and -not (Test-Path -LiteralPath $FirstSourcePath)) {
     throw "First source path was not found: $FirstSourcePath"
 }
 
@@ -128,13 +151,23 @@ try {
     $firstOutput = Join-Path $outputFullPath 'first-hdr10plus'
     $secondOutput = Join-Path $outputFullPath 'second-non-hdr10plus'
 
-    Invoke-BDInfoInProcess @($FirstSourcePath, $outputFullPath, '--list')
-    Invoke-BDInfoInProcess @($FirstSourcePath, $firstOutput, '-m', $FirstPlaylist, '-r', $ReportFormats)
-    Assert-ReportsContainHdr10Plus $firstOutput $ReportFormats
+    if ($SyntheticFirst) {
+        Set-SyntheticHdr10PlusState
+    }
+    else {
+        Invoke-BDInfoInProcess @($FirstSourcePath, $outputFullPath, '--list')
+        Invoke-BDInfoInProcess @($FirstSourcePath, $firstOutput, '-m', $FirstPlaylist, '-r', $ReportFormats)
+        Assert-ReportsContainHdr10Plus $firstOutput $ReportFormats
+    }
 
     if ($WaitForDiscSwap) {
         Write-Host ''
-        Write-Host 'Swap to a known non-HDR10+ disc without closing this PowerShell process.'
+        if ($SyntheticFirst) {
+            Write-Host 'Insert or keep a known non-HDR10+ disc without closing this PowerShell process.'
+        }
+        else {
+            Write-Host 'Swap to a known non-HDR10+ disc without closing this PowerShell process.'
+        }
         if ([string]::IsNullOrWhiteSpace($SecondPlaylist)) {
             $SecondPlaylist = Read-Host 'Enter the non-HDR10+ playlist number, for example 00107'
         }


### PR DESCRIPTION
## Summary

- add `-SyntheticFirst` to `scripts/smoke-hdr10plus-swap-local.ps1`
- seed HDR10+ HEVC state in-process before scanning a real non-HDR10+ disc
- document the mode in `AGENTS.md` and `README.md`
- record the successful `V:\` / `00001.MPLS` non-HDR10+ verification in `ROADMAP.md`

## Verification

- [x] `scripts/smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001`
- [x] PowerShell parser check for `scripts/smoke-hdr10plus-swap-local.ps1`
- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`
- [x] `scripts/smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SelfTest`

## Risk Notes

- GUI impact: none; this extends a local smoke script.
- CLI impact: no production CLI behavior change; the script calls existing CLI runner in-process.
- Report format/backward compatibility impact: none expected; the real non-HDR10+ reports were checked for absence of `HDR10+`.

## Release Notes

- Extended the HDR10+ swap smoke with a synthetic-first mode for validating real non-HDR10+ discs without a HDR10+ disc in the drive.