### PR TITLE
[codex] Complete HDR10+ real swap verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,12 @@ When only a non-HDR10+ disc is available, use the synthetic-first mode to seed H
 & .\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001
 ```
 
+For unattended coordination with this thread, use signal files so the smoke can pause after the first scan and continue after the disc swap:
+
+```powershell
+& .\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -SecondPlaylist 00000 -SwapReadySignalPath .\tmp_swap\swap-ready.signal -DiscReadySignalPath .\tmp_swap\disc-ready.signal -KeepOutput
+```
+
 Clean temporary smoke output before committing.
 
 If report fixture models change intentionally, regenerate the synthetic committed fixtures with:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Required checks before publishing a branch:
 - Real-disc HDR10+ smoke when sample media is available: `.\scripts\smoke-hdr10plus-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00800`
 - `.bdinfo` round-trip check for report serialization changes
 
-Manual HDR10+ carryover verification requires one process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing the process, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`. The same-process CLI path can be checked with `.\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap`; when only a non-HDR10+ disc is available, use `-SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001`.
+Manual HDR10+ carryover verification requires one process: scan an HDR10+ title, swap to a known non-HDR10+ disc without closing the process, scan the non-HDR10+ playlist, then export the second report and confirm it does not contain `HDR10+`. The same-process CLI path can be checked with `.\scripts\smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -FirstSourcePath V:\ -FirstPlaylist 00800 -SecondSourcePath V:\ -WaitForDiscSwap`; when only a non-HDR10+ disc is available, use `-SyntheticFirst -SecondSourcePath V:\ -SecondPlaylist 00001`. For noninteractive coordination, pass `-SwapReadySignalPath` and `-DiscReadySignalPath`.
 
 Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests should use the repository PR template.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,13 +143,14 @@ These items should be handled after `v0.7.6.2-clicli.1`, one small PR at a time.
 
 ### 8. Recheck HDR10+ Carryover Fix
 
-Status: in progress.
+Status: done.
 
 Progress:
 - Added an automated smoke that verifies a fresh HEVC stream does not inherit HDR10+ state from a previous HEVC stream in the same process.
 - Added a local real-disc HDR10+ smoke script for sample media and verified `V:\` / `00800.MPLS` exports `HDR10+` in text, XML `.bdinfo`, and JSON `.bdinfo` reports with charts.
 - Added a same-process local swap smoke that scans HDR10+ media, pauses for a manual non-HDR10+ disc swap, then checks that the second report does not contain `HDR10+`.
 - Added a synthetic-first same-process mode and verified it against a real non-HDR10+ disc at `V:\` / `00001.MPLS`; the second text, XML `.bdinfo`, and JSON `.bdinfo` reports did not contain `HDR10+`.
+- Completed a full real-disc same-process swap: HDR10+ `V:\` / `00800.MPLS` (`ELVIS`) followed by HDR10/non-HDR10+ `V:\` / `00000.MPLS` (`THE_AFRICAN_QUEEN`), with no `HDR10+` in the second text, XML `.bdinfo`, or JSON `.bdinfo` report.
 
 Goal: verify that the documented HDR10+ carryover fix still behaves correctly after the report/export/load refactors.
 

--- a/scripts/smoke-hdr10plus-swap-local.ps1
+++ b/scripts/smoke-hdr10plus-swap-local.ps1
@@ -6,6 +6,9 @@ param(
     [string] $FirstPlaylist = '00800',
     [string] $SecondPlaylist,
     [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
+    [string] $SwapReadySignalPath,
+    [string] $DiscReadySignalPath,
+    [int] $DiscReadyPollSeconds = 2,
     [switch] $SelfTest,
     [switch] $SyntheticFirst,
     [switch] $WaitForDiscSwap,
@@ -52,6 +55,25 @@ function Set-SyntheticHdr10PlusState {
     }
 
     Write-Host 'Synthetic HDR10+ state set in current process.'
+}
+
+function Wait-ForDiscReadySignal([string] $ReadyPath, [string] $ContinuePath) {
+    $readyFullPath = Resolve-FullPath $ReadyPath
+    $continueFullPath = Resolve-FullPath $ContinuePath
+
+    $readyDirectory = Split-Path -Parent $readyFullPath
+    if ($readyDirectory) {
+        New-Item -ItemType Directory -Force -Path $readyDirectory | Out-Null
+    }
+
+    Set-Content -LiteralPath $readyFullPath -Value ([DateTime]::UtcNow.ToString('O'))
+    Write-Host "Waiting for disc-ready signal: $continueFullPath"
+
+    while (-not (Test-Path -LiteralPath $continueFullPath -PathType Leaf)) {
+        Start-Sleep -Seconds $DiscReadyPollSeconds
+    }
+
+    Remove-Item -LiteralPath $continueFullPath -Force
 }
 
 function Assert-DirectoryExists([string] $Path, [string] $Description) {
@@ -160,7 +182,22 @@ try {
         Assert-ReportsContainHdr10Plus $firstOutput $ReportFormats
     }
 
-    if ($WaitForDiscSwap) {
+    if ($DiscReadySignalPath) {
+        if ([string]::IsNullOrWhiteSpace($SwapReadySignalPath)) {
+            throw 'SwapReadySignalPath is required when DiscReadySignalPath is used.'
+        }
+
+        Write-Host ''
+        if ($SyntheticFirst) {
+            Write-Host 'Insert or keep a known non-HDR10+ disc without closing this PowerShell process.'
+        }
+        else {
+            Write-Host 'Swap to a known non-HDR10+ disc without closing this PowerShell process.'
+        }
+
+        Wait-ForDiscReadySignal $SwapReadySignalPath $DiscReadySignalPath
+    }
+    elseif ($WaitForDiscSwap) {
         Write-Host ''
         if ($SyntheticFirst) {
             Write-Host 'Insert or keep a known non-HDR10+ disc without closing this PowerShell process.'


### PR DESCRIPTION
## Summary

- mark roadmap item 8 as done after completing the full real-disc same-process HDR10+ carryover swap
- document signal-file coordination for `smoke-hdr10plus-swap-local.ps1`
- add signal-file parameters so the smoke can pause after the first scan and resume after a manual disc swap

## Verification

- [x] Full real-disc same-process swap: HDR10+ `V:\` / `00800.MPLS` (`ELVIS`) followed by HDR10/non-HDR10+ `V:\` / `00000.MPLS` (`THE_AFRICAN_QUEEN`)
- [x] Confirmed no `HDR10+` in the second text, XML `.bdinfo`, or JSON `.bdinfo` reports
- [x] PowerShell parser check for `scripts/smoke-hdr10plus-swap-local.ps1`
- [x] `scripts/smoke-hdr10plus-swap-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SelfTest`
- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`

## Risk Notes

- GUI impact: none; verification script/docs only.
- CLI impact: no production CLI behavior change; the script still calls the existing runner in-process.
- Report format/backward compatibility impact: none expected; this verifies absence of carryover in generated reports.

## Release Notes

- Completed HDR10+ carryover verification with a real same-process disc swap and documented the signal-file workflow.