### PR TITLE
[codex] Add project tracking documentation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -204,6 +204,14 @@ Done when:
 
 ### 11. Project Tracking
 
+Status: done.
+
+Progress:
+- Enabled GitHub Issues for `ttonych/BDInfo_clicli`.
+- Added repository labels: `cli`, `gui`, `report`, `scanner`, `release`, and `needs-sample`.
+- Created actionable scanner issues #49 and #50 from `docs/BDROM_TODO_AUDIT.md`.
+- Added `docs/PROJECT_TRACKING.md`.
+
 Goal: make future maintenance easier to track outside this working thread.
 
 Scope:

--- a/docs/PROJECT_TRACKING.md
+++ b/docs/PROJECT_TRACKING.md
@@ -1,0 +1,30 @@
+# Project Tracking
+
+GitHub Issues are enabled for this fork. Use issues for actionable maintenance work, not for every observation or uncertain parser limitation.
+
+## Labels
+
+Repository-specific labels:
+
+- `cli`: command-line interface behavior.
+- `gui`: WinForms GUI behavior.
+- `report`: report generation, serialization, and loading.
+- `scanner`: BDROM parser and stream scanner behavior.
+- `release`: release packaging and versioning.
+- `needs-sample`: needs real disc or sample media to verify safely.
+
+The default GitHub labels remain available for general triage.
+
+## Current Issues
+
+- [#49 Harden PMT descriptor parsing and diagnostics](https://github.com/ttonych/BDInfo_clicli/issues/49)
+- [#50 Add defensive bounds checks for playlist chapter parsing](https://github.com/ttonych/BDInfo_clicli/issues/50)
+
+Both issues came from `docs/BDROM_TODO_AUDIT.md` and should be handled as small PRs into `UHD_Support`.
+
+## Rules
+
+- Open an issue only when the next action is clear.
+- Add `needs-sample` when a real disc or sample media is required before changing scanner behavior.
+- Keep speculative codec/parser limitations in docs until a sample or report makes the problem actionable.
+- Close issues from PR descriptions when the fix is merged and verified.


### PR DESCRIPTION
## Summary

- document project tracking rules in `docs/PROJECT_TRACKING.md`
- mark roadmap item 11 as done
- record that GitHub Issues are enabled, repository labels are available, and actionable scanner issues #49/#50 exist

## Verification

- [x] Enabled GitHub Issues
- [x] Created labels: `cli`, `gui`, `report`, `scanner`, `release`, `needs-sample`
- [x] Created issues #49 and #50
- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`

## Risk Notes

- GUI impact: none; documentation and repository tracking only.
- CLI impact: none.
- Report format/backward compatibility impact: none.

## Release Notes

- Enabled issue-based project tracking and documented labels and current actionable scanner issues.