### PR TITLE
Automate release notes generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,5 +111,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
           files: |
             BDInfo_clicli.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Before finalizing a PR, verify:
 - Fill in `.github/pull_request_template.md`.
 - Wait for GitHub Actions to pass before merging.
 - Dependabot is enabled for NuGet packages and GitHub Actions. Treat its PRs like normal code changes: review the diff, wait for CI, and merge only when the update is relevant.
-- Use tag pushes for releases. The build workflow attaches `BDInfo_clicli.zip` to tags matching `v*.*.*`.
+- Use tag pushes for releases. The build workflow attaches `BDInfo_clicli.zip` and asks GitHub to generate release notes for tags matching `v*.*.*`.
 - Suggested tag format for this fork: `v0.7.6.2-clicli.N`.
 
 Recommended GitHub repository settings:


### PR DESCRIPTION
## Summary

- enable GitHub auto-generated release notes for tag releases
- make the release step fail when `BDInfo_clicli.zip` is missing instead of publishing an empty release asset set
- update `AGENTS.md` so the release workflow rule matches the workflow behavior

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`

## Risk Notes

- GUI impact: none.
- CLI impact: none.
- Report format/backward compatibility impact: none.
- Release impact: future tag releases should no longer be created with empty release notes; release upload will fail if the ZIP glob does not match.

## Release Notes

- Improved release workflow automation for future tag builds.
