### PR TITLE
Document report format policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This repository is a long-lived personal fork of BDInfo. Treat it as a production tool even when changes are small: preserve GUI behavior, keep CLI behavior explicit, and verify report round-trips before shipping.
 
+Report format policy lives in `docs/REPORT_FORMATS.md`. In short: keep text reports close to original BDInfo unless fixing wrong output; call out every intentional text report change in PR/release notes; treat `.bdinfo` as an internal application snapshot format; target compressed JSON as the canonical Snapshot v2 format; treat XML as deprecated/best-effort proof-of-concept compatibility.
+
 ## Operating Rules
 
 - Work from a clean, named branch for every task. Use `codex/<short-task-name>` unless the user asks for another branch name.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 BDInfo_clicli forks **https://github.com/UniqProject/BDInfo** (tag v0.7.6.2_1b https://github.com/UniqProject/BDInfo/releases/tag/v0.7.6.2_1b). UniqProject/BDInfo itself is not the original BDInfo—the original project is from CinemaSquid: http://www.cinemasquid.com/blu-ray/tools/bdinfo
 
 - **Export & reload .bdinfo reports** (export via **CLI** and **GUI**; open/reload in **GUI**)
-- **Report formats: JSON and XML** (the `.bdinfo` file can be either; format is auto‑detected; optional ZIP compression)
+- **Report snapshots: JSON and XML today** (Snapshot v2 will make compressed JSON the canonical `.bdinfo` form; see [`docs/REPORT_FORMATS.md`](docs/REPORT_FORMATS.md))
 - **HDR10+ carryover bug fix** in video stream metadata
 - A simple **command‑line (CLI) mode** for headless use
 
@@ -51,6 +51,15 @@ You can choose the **report format** when exporting: **JSON** or **XML**. The ex
 - **GUI export formats**: **XML `.bdinfo`**, **JSON `.bdinfo`**, **compressed XML `.bdinfo`**, **compressed JSON `.bdinfo`**, and **text `.txt`** are available from the export dialog.
 - **Open/reload**: supported **only in the GUI**. Click **Load Report...** and select a previously saved `.bdinfo` file. BDInfo **automatically detects** JSON vs XML and also loads ZIP-compressed `.bdinfo` reports.
 - **Use case**: scan once on a server/headless box, then send the `.bdinfo` to someone who can open it in the GUI and review details/charts without access to the disc.
+
+Format direction:
+- Text `.txt` is the legacy human-readable report and should stay close to original BDInfo output.
+- `.bdinfo` is an application snapshot format, not a public stable API.
+- Compressed JSON is the target canonical `.bdinfo` snapshot format for Snapshot v2.
+- XML is proof-of-concept/deprecated and should not be extended without a specific compatibility need.
+- Charts are derived visual artifacts, not the source of truth for reports.
+
+See [`docs/REPORT_FORMATS.md`](docs/REPORT_FORMATS.md) for the full policy.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -320,3 +320,76 @@ Done when:
 Release:
 - [`v0.7.6.2-clicli.2`](https://github.com/ttonych/BDInfo_clicli/releases/tag/v0.7.6.2-clicli.2)
 - Includes `BDInfo_clicli.zip`.
+
+## Report Format Policy And Snapshot v2
+
+This phase defines the report/snapshot format direction before changing serializers. The text report remains the legacy user-facing output; `.bdinfo` becomes an internal application snapshot format with compressed JSON as the target canonical representation.
+
+### 16. Document Report Format Policy
+
+Status: next.
+
+Goal: make the format policy explicit so future code changes do not preserve accidental proof-of-concept behavior.
+
+Scope:
+- Document text report compatibility rules.
+- Document `.bdinfo` as an application snapshot, not a public stable API.
+- Document compressed JSON as the target canonical snapshot format.
+- Document XML as deprecated/best-effort proof-of-concept compatibility.
+- Document charts as derived visual artifacts, not report source of truth.
+
+Done when:
+- `docs/REPORT_FORMATS.md` exists.
+- README and `AGENTS.md` point to the policy.
+- Future PRs have clear rules for text report changes and snapshot changes.
+
+### 17. Audit Current Report Pipeline
+
+Status: pending.
+
+Goal: map current code to the new policy before refactoring.
+
+Scope:
+- Audit `BDInfo/Report/ReportModels.cs`.
+- Audit `BDInfo/Report/ReportSerializer.cs`.
+- Audit `BDInfo/CliReportWriter.cs`.
+- Audit `BDInfo/GuiReportLoader.cs`.
+- Audit GUI export selection and default behavior.
+
+Done when:
+- The current text-report path and snapshot path are documented.
+- Serializer drift and compatibility risks are listed.
+- Snapshot v2 implementation tasks are split into small PRs.
+
+### 18. Implement Snapshot v2 Envelope
+
+Status: pending.
+
+Goal: add an explicit snapshot envelope with schema/version metadata.
+
+Scope:
+- Add `format`, `schemaVersion`, `payloadKind`, `createdBy`, `createdAt`, and `payload`.
+- Make compressed JSON the canonical `.bdinfo` snapshot output.
+- Keep raw JSON as a development/debug export if useful.
+- Decide whether XML export remains visible, deprecated, or removed.
+
+Done when:
+- New `.bdinfo` files are versioned compressed JSON snapshots.
+- Loader identifies Snapshot v2 by envelope fields, not only extension.
+- Round-trip smoke covers Snapshot v2.
+
+### 19. Update Report Fixtures And Documentation
+
+Status: pending.
+
+Goal: make tests and user docs match Snapshot v2.
+
+Scope:
+- Regenerate or replace report round-trip fixtures.
+- Update README examples and format descriptions.
+- Update `AGENTS.md` verification notes if commands or expectations change.
+
+Done when:
+- CI validates Snapshot v2 round-trip.
+- README no longer presents XML and JSON snapshots as equally preferred future formats.
+- Any intentional text report output changes are separately documented.

--- a/docs/REPORT_FORMATS.md
+++ b/docs/REPORT_FORMATS.md
@@ -1,0 +1,87 @@
+# Report Format Policy
+
+This fork has two different output families:
+
+- human-readable reports, where compatibility with original BDInfo matters;
+- application snapshots, where reliable GUI reload and chart regeneration matter more than preserving early proof-of-concept file shapes.
+
+## Format Roles
+
+### Text Report (`.txt`)
+
+The text report is the legacy, user-facing BDInfo report.
+
+Policy:
+- Keep the output as close to original/upstream BDInfo as practical.
+- Change text output only to fix clearly wrong information, add explicitly intended data, or preserve existing behavior after a refactor.
+- Any intentional text report change must be called out in the PR notes and release notes.
+- For text report changes, include a before/after snippet when practical.
+
+### BDInfo Snapshot (`.bdinfo`)
+
+The `.bdinfo` file is an application snapshot, not a public stable API.
+
+Current behavior before Snapshot v2:
+- XML `.bdinfo` and JSON `.bdinfo` can both be exported.
+- ZIP-compressed XML/JSON `.bdinfo` can both be exported.
+- The GUI loader auto-detects JSON, XML, and ZIP-compressed `.bdinfo` files.
+
+Target policy:
+- The canonical snapshot format is compressed JSON `.bdinfo`.
+- CLI `-r bdinfo` should mean canonical compressed JSON `.bdinfo`.
+- GUI text export remains the default human-readable export.
+- Raw JSON can remain available as a development/debug export.
+- XML is deprecated. Do not extend XML unless a specific compatibility need is identified.
+- Support for old proof-of-concept XML/JSON `.bdinfo` files is best effort only; do not block Snapshot v2 on preserving old POC shapes.
+
+### Compressed `.bdinfo`
+
+Compression is a storage/container choice, not a separate data model.
+
+Policy:
+- Compressed and uncompressed snapshots must load to equivalent report data.
+- Compression is preferred for normal exchange/storage because raw XML/JSON snapshots are large.
+- Compression must not change report semantics.
+
+### Charts
+
+Charts are derived visual artifacts.
+
+Policy:
+- Charts are not a canonical report format.
+- GUI chart generation comes from upstream BDInfo behavior.
+- CLI chart export is automation around the existing chart generation path.
+- Snapshot data should contain enough chart source data to regenerate charts without the original disc.
+
+## Snapshot v2 Requirements
+
+Snapshot v2 should have an explicit envelope so future versions can evolve without guessing by extension or serializer details.
+
+Required envelope fields:
+- `format`: `BDInfo_clicli`
+- `schemaVersion`: integer version, starting with `2`
+- `payloadKind`: `reportSnapshot`
+- `createdBy`: application name/version
+- `createdAt`: timestamp in a stable format
+- `payload`: report snapshot data
+
+Snapshot data should include:
+- report data needed to regenerate the text report;
+- chart source data needed by the GUI chart views;
+- scan metadata useful for users, such as volume label, playlist names, scan time, and app version;
+- non-fatal scanner warnings or diagnostics when they are useful and structured.
+
+Snapshot data should not include:
+- temporary local output paths;
+- machine-specific cache paths;
+- assumptions that the original disc is still available.
+
+## Migration Plan
+
+1. Document this policy before changing serializers.
+2. Audit `ReportModels`, `ReportSerializer`, `CliReportWriter`, `GuiReportLoader`, and GUI export selection against this policy.
+3. Add Snapshot v2 DTO/envelope support.
+4. Make compressed JSON `.bdinfo` the canonical snapshot output.
+5. Keep XML load/export only if it remains cheap; otherwise remove or hide XML export as part of a deliberate PR.
+6. Update fixtures and smoke scripts for Snapshot v2.
+7. Record every intentional text report change separately from snapshot-format changes.


### PR DESCRIPTION
## Summary

- add `docs/REPORT_FORMATS.md` with the agreed report/snapshot policy
- document Snapshot v2 direction: text stays legacy, `.bdinfo` is an internal snapshot, compressed JSON becomes canonical, XML is deprecated/best-effort
- add roadmap items for report pipeline audit, Snapshot v2 envelope, fixtures, and docs
- link the policy from README and AGENTS.md

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization
- [x] `scripts/smoke-hdr10plus-carryover.ps1`

## Risk Notes

- GUI impact: none, documentation only.
- CLI impact: none, documentation only.
- Report format/backward compatibility impact: no code changes yet; this documents the target policy for future Snapshot v2 work.

## Release Notes

- Documented the report format policy and Snapshot v2 direction.
