### PR TITLE
Audit report pipeline for Snapshot v2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -327,7 +327,7 @@ This phase defines the report/snapshot format direction before changing serializ
 
 ### 16. Document Report Format Policy
 
-Status: next.
+Status: done in [#59](https://github.com/ttonych/BDInfo_clicli/pull/59).
 
 Goal: make the format policy explicit so future code changes do not preserve accidental proof-of-concept behavior.
 
@@ -345,7 +345,7 @@ Done when:
 
 ### 17. Audit Current Report Pipeline
 
-Status: pending.
+Status: done in `docs/REPORT_PIPELINE_AUDIT.md`.
 
 Goal: map current code to the new policy before refactoring.
 
@@ -363,7 +363,7 @@ Done when:
 
 ### 18. Implement Snapshot v2 Envelope
 
-Status: pending.
+Status: next.
 
 Goal: add an explicit snapshot envelope with schema/version metadata.
 
@@ -393,3 +393,37 @@ Done when:
 - CI validates Snapshot v2 round-trip.
 - README no longer presents XML and JSON snapshots as equally preferred future formats.
 - Any intentional text report output changes are separately documented.
+
+### 20. Align CLI Snapshot Semantics
+
+Status: pending.
+
+Goal: make CLI report format names match the Snapshot v2 policy.
+
+Scope:
+- Change `-r bdinfo` to write canonical compressed JSON `.bdinfo`.
+- Keep raw JSON under an explicit development/debug format name.
+- Keep XML only under an explicit deprecated name if XML export remains available.
+- Update CLI help, README, smoke scripts, and PR/release notes.
+
+Done when:
+- CLI behavior matches `docs/REPORT_FORMATS.md`.
+- Existing text report behavior is unchanged unless separately documented.
+- Snapshot round-trip smoke covers canonical compressed JSON.
+
+### 21. Align GUI Export Semantics
+
+Status: pending.
+
+Goal: make GUI export defaults match the Snapshot v2 policy.
+
+Scope:
+- Make text `.txt` the default GUI export.
+- Make compressed JSON `.bdinfo` the preferred snapshot export.
+- Decide whether XML export is hidden, removed, or left as explicit deprecated export.
+- Update README and manual verification notes.
+
+Done when:
+- GUI export default is text.
+- Snapshot export is still available.
+- User-visible behavior changes are called out in PR/release notes.

--- a/docs/REPORT_PIPELINE_AUDIT.md
+++ b/docs/REPORT_PIPELINE_AUDIT.md
@@ -1,0 +1,176 @@
+# Report Pipeline Audit
+
+This audit maps the current report code to the policy in `docs/REPORT_FORMATS.md`.
+
+## Current Pipeline
+
+### Text Report
+
+Entry points:
+- CLI: `CliReportWriter.WriteReports` creates a `FormReport`, calls `Generate`, and writes `FormReport.ReportText`.
+- GUI: `FormReport.Generate` builds the visible text report and the export button can write the same text box content to `.txt`.
+
+Current behavior:
+- Text report generation is owned by `FormReport.Generate`.
+- The text report is built directly from runtime `BDROM`, `TSPlaylistFile`, `TSStream`, and `ScanBDROMResult` objects.
+- Text export is not serialized through `ReportModels`.
+
+Policy impact:
+- Keep this path stable and close to upstream/original BDInfo.
+- Snapshot v2 work should not rewrite text report output unless a separate PR explicitly documents the text diff.
+
+### Snapshot Model
+
+Files:
+- `BDInfo/Report/ReportModels.cs`
+- `BDInfo/Report/ReportSerializer.cs`
+
+Current behavior:
+- `BDInfoReportData` is the root persistence DTO.
+- There is no explicit envelope with `format`, `schemaVersion`, or `payloadKind`.
+- XML and JSON serialize the same `BDInfoReportData` graph through `DataContractSerializer` / `DataContractJsonSerializer`.
+- Runtime objects are converted into DTOs by `BDInfoReportSerializer.BuildDiscData`.
+- DTOs are converted back into runtime objects by `BDInfoReportSerializer.CreateBDROM`.
+
+Observed risks:
+- The root DTO is both the payload and the format contract, which leaves no clean place for schema/version metadata.
+- `StreamData` is a broad flattened DTO with video, audio, subtitle, graphics, and common fields on the base type. This is easy to serialize but creates noisy raw JSON/XML and weakens type boundaries.
+- Some runtime details are persisted because they are needed for charts and round-trip, but there is no clear split between report data, chart source data, scan metadata, and diagnostics.
+- `SourcePath` is saved from the scanned source, then overwritten with the loaded `.bdinfo` path during load. Snapshot v2 should separate source identity from loaded-from path, and avoid relying on local machine paths as core data.
+- `ScanFileExceptionData` currently persists stack traces. That is useful for debugging, but too noisy and potentially machine-specific for a normal exchange snapshot.
+
+### Snapshot Serialization
+
+Current behavior:
+- Raw XML and raw JSON are written directly to `.bdinfo`.
+- Compressed `.bdinfo` is a ZIP archive with `report.xml` or `report.json`.
+- Load detects ZIP by `PK`, then prefers `report.json`, then `report.xml`, then the first non-empty entry.
+- Non-ZIP load detects JSON by the first non-whitespace byte `{` or `[`; otherwise it assumes XML.
+
+Policy impact:
+- Snapshot v2 should prefer compressed JSON and identify the format by envelope fields.
+- ZIP entry selection should be stricter for Snapshot v2, because "first non-empty entry" is useful for POC compatibility but weak for a canonical format.
+- Raw JSON can remain useful for development/debug output.
+- XML should not receive new features unless there is a deliberate compatibility reason.
+
+### CLI Export
+
+Files:
+- `BDInfo/CliArgumentParser.cs`
+- `BDInfo/CliReportWriter.cs`
+- `BDInfo/ConsoleRunner.cs`
+
+Current behavior:
+- Default CLI report format is text.
+- `-r bdinfo` and `-r bdinfo-xml` mean XML `.bdinfo`.
+- `-r bdinfo-json` and `-r json` mean JSON `.bdinfo`.
+- `-z/--compress` controls compression for XML and JSON snapshot formats.
+- When XML and JSON are both requested, JSON gets `.json.bdinfo` to avoid overwriting XML `.bdinfo`.
+
+Policy gap:
+- Target policy says CLI `-r bdinfo` should mean canonical compressed JSON `.bdinfo`.
+- That means `ReportFormat.Bdinfo` should stop meaning XML once Snapshot v2 is implemented.
+- Compression should become the default for canonical `bdinfo`; raw JSON should be explicit debug/development output.
+
+### GUI Export And Load
+
+Files:
+- `BDInfo/FormReport.cs`
+- `BDInfo/GuiReportExportSelection.cs`
+- `BDInfo/GuiReportLoader.cs`
+
+Current behavior:
+- GUI export dialog first filter is XML `.bdinfo`.
+- GUI text export is filter 5, not the default.
+- GUI default extension is `.bdinfo`.
+- GUI loader accepts any `.bdinfo`, then delegates format detection to `BDInfoReportSerializer.Load`.
+
+Policy gap:
+- Target policy says GUI default export should be text.
+- Snapshot export should still be available, but canonical Snapshot v2 should be compressed JSON.
+- XML export should be deprecated, hidden, or removed as a deliberate follow-up decision.
+
+### Charts
+
+Current behavior:
+- GUI charts are generated from restored runtime objects.
+- CLI chart export automates `FormChart`.
+- Snapshot data includes enough stream diagnostics and playlist/stream structure for chart regeneration in current smoke coverage.
+
+Policy impact:
+- Charts should remain derived artifacts.
+- Snapshot v2 must preserve chart source data, but should not treat rendered image files as report data.
+
+### Fixtures And Smoke
+
+Files:
+- `scripts/smoke-report-roundtrip.ps1`
+- `tests/fixtures/report-roundtrip`
+
+Current behavior:
+- Fixtures cover raw XML, raw JSON, compressed XML, and compressed JSON.
+- The smoke script creates synthetic `BDInfoReportData` directly through PowerShell reflection.
+- The smoke verifies load, runtime object reconstruction, stream diagnostics, and scan file exceptions.
+
+Policy impact:
+- Snapshot v2 fixtures should focus on canonical compressed JSON.
+- Old XML/JSON POC fixtures do not need permanent compatibility guarantees.
+- If XML load is retained temporarily, keep a small XML fixture only as a legacy/best-effort check.
+
+## Recommended Implementation Plan
+
+### PR A: Snapshot v2 DTO Envelope
+
+Add a new envelope type around the current payload:
+- `format`
+- `schemaVersion`
+- `payloadKind`
+- `createdBy`
+- `createdAt`
+- `payload`
+
+Keep the initial payload close to current `BDInfoReportData` to reduce blast radius. Do not rewrite text report output in this PR.
+
+### PR B: Canonical JSON Save/Load
+
+Add explicit save/load paths for Snapshot v2 compressed JSON:
+- write ZIP `.bdinfo` with a deterministic JSON entry name;
+- detect Snapshot v2 by envelope fields;
+- keep raw JSON output available only through an explicit format name;
+- keep old POC load only as best effort if it remains cheap.
+
+### PR C: CLI Format Semantics
+
+Change CLI semantics to match policy:
+- `-r bdinfo` writes canonical compressed JSON `.bdinfo`;
+- raw JSON uses an explicit name such as `bdinfo-json`;
+- XML uses an explicit deprecated name if still available;
+- update help, README, and smoke scripts in the same PR.
+
+This is a user-visible CLI behavior change and must be called out in release notes.
+
+### PR D: GUI Export Semantics
+
+Change GUI export defaults to match policy:
+- text `.txt` is the default GUI export;
+- compressed JSON `.bdinfo` is the preferred snapshot export;
+- XML export is deprecated, hidden, or removed by explicit decision.
+
+This is a user-visible GUI behavior change and must be called out in release notes.
+
+### PR E: Fixtures And Cleanup
+
+Update test fixtures and smoke scripts:
+- add Snapshot v2 compressed JSON fixture;
+- remove or demote old POC fixtures;
+- verify compressed and raw JSON load to equivalent data when raw JSON remains available;
+- avoid blocking Snapshot v2 on old POC XML/JSON compatibility.
+
+### PR F: DTO Size/Shape Cleanup
+
+After Snapshot v2 is working, reduce DTO noise:
+- split common stream fields from video/audio/graphics/text-specific fields where useful;
+- remove fields that are not needed for report text, chart regeneration, or structured diagnostics;
+- avoid persisting local paths or stack traces in normal snapshots.
+
+Do this after Snapshot v2 semantics are covered by smoke tests.


### PR DESCRIPTION
## Summary

- add `docs/REPORT_PIPELINE_AUDIT.md` mapping the current text report, snapshot serializer, CLI, GUI, charts, and fixture paths
- identify Snapshot v2 gaps: no envelope, `-r bdinfo` currently means XML, GUI export defaults to XML, and current DTOs are noisy
- update roadmap status for report format policy and set Snapshot v2 envelope as the next implementation step

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [ ] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [ ] Exported `.bdinfo` round-trip checked, if this touches report serialization

## Risk Notes

- GUI impact: none, documentation only.
- CLI impact: none, documentation only.
- Report format/backward compatibility impact: no code changes yet; this documents the Snapshot v2 implementation plan.

## Release Notes

- Not needed; report pipeline audit documentation only.
