### PR TITLE
[codex] Add Snapshot v2 envelope support

### DIFF
--- a/BDInfo/Report/ReportModels.cs
+++ b/BDInfo/Report/ReportModels.cs
@@ -257,4 +257,15 @@ namespace BDInfo.Reporting
         [DataMember] public BDROMData Disc;
         [DataMember] public ScanResultData ScanResult;
     }
+
+    [DataContract]
+    public class BDInfoSnapshotData
+    {
+        [DataMember(Name = "format")] public string Format;
+        [DataMember(Name = "schemaVersion")] public int SchemaVersion;
+        [DataMember(Name = "payloadKind")] public string PayloadKind;
+        [DataMember(Name = "createdBy")] public string CreatedBy;
+        [DataMember(Name = "createdAt")] public string CreatedAt;
+        [DataMember(Name = "payload")] public BDInfoReportData Payload;
+    }
 }

--- a/BDInfo/Report/ReportSerializer.cs
+++ b/BDInfo/Report/ReportSerializer.cs
@@ -19,9 +19,19 @@ namespace BDInfo.Reporting
 
     public static class BDInfoReportSerializer
     {
+        public const string SnapshotFormat = "BDInfo_clicli";
+        public const int SnapshotSchemaVersion = 2;
+        public const string SnapshotPayloadKind = "reportSnapshot";
+
         private static readonly DataContractSerializer XmlSerializer = new DataContractSerializer(typeof(BDInfoReportData));
         private static readonly DataContractJsonSerializer JsonSerializer = new DataContractJsonSerializer(
             typeof(BDInfoReportData),
+            new DataContractJsonSerializerSettings
+            {
+                UseSimpleDictionaryFormat = true
+            });
+        private static readonly DataContractJsonSerializer SnapshotJsonSerializer = new DataContractJsonSerializer(
+            typeof(BDInfoSnapshotData),
             new DataContractJsonSerializerSettings
             {
                 UseSimpleDictionaryFormat = true
@@ -46,14 +56,7 @@ namespace BDInfo.Reporting
             }
 
             var playlistList = playlists.ToList();
-            var report = new BDInfoReportData
-            {
-                CreatedUtc = DateTime.UtcNow,
-                Version = typeof(BDInfoReportSerializer).Assembly.GetName().Version?.ToString(),
-                SourcePath = GetSourcePath(bdrom),
-                Disc = BuildDiscData(bdrom, playlistList),
-                ScanResult = ConvertScanResult(scanResult)
-            };
+            var report = BuildReportData(bdrom, playlistList, scanResult);
 
             string directory = Path.GetDirectoryName(path);
             if (string.IsNullOrWhiteSpace(directory))
@@ -80,6 +83,54 @@ namespace BDInfo.Reporting
                 using (var stream = File.Create(path))
                 {
                     WriteReport(stream, report, format);
+                }
+            }
+        }
+
+        public static void SaveSnapshotV2(
+            string path,
+            BDROM bdrom,
+            IEnumerable<TSPlaylistFile> playlists,
+            ScanBDROMResult scanResult,
+            bool compress = true)
+        {
+            if (bdrom == null)
+            {
+                throw new ArgumentNullException(nameof(bdrom));
+            }
+
+            if (playlists == null)
+            {
+                throw new ArgumentNullException(nameof(playlists));
+            }
+
+            var report = BuildReportData(bdrom, playlists.ToList(), scanResult);
+            var snapshot = CreateSnapshot(report);
+
+            string directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                directory = ".";
+            }
+            Directory.CreateDirectory(directory);
+
+            if (compress)
+            {
+                using (var fileStream = File.Create(path))
+                using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+                {
+                    var entry = archive.CreateEntry("snapshot.json", CompressionLevel.Optimal);
+                    using (var entryStream = entry.Open())
+                    {
+                        WriteSnapshot(entryStream, snapshot);
+                    }
+                }
+            }
+            else
+            {
+                using (var stream = File.Create(path))
+                {
+                    WriteSnapshot(stream, snapshot);
                 }
             }
         }
@@ -203,6 +254,8 @@ namespace BDInfo.Reporting
             }
 
             var entry = archive.Entries
+                .FirstOrDefault(e => string.Equals(e.Name, "snapshot.json", StringComparison.OrdinalIgnoreCase))
+                       ?? archive.Entries
                 .FirstOrDefault(e => string.Equals(e.Name, "report.json", StringComparison.OrdinalIgnoreCase))
                        ?? archive.Entries
                 .FirstOrDefault(e => string.Equals(e.Name, "report.xml", StringComparison.OrdinalIgnoreCase));
@@ -248,15 +301,31 @@ namespace BDInfo.Reporting
             }
         }
 
+        private static void WriteSnapshot(Stream stream, BDInfoSnapshotData snapshot)
+        {
+            using (var writer = JsonReaderWriterFactory.CreateJsonWriter(
+                       stream,
+                       Encoding.UTF8,
+                       ownsStream: false,
+                       indent: true,
+                       indentChars: "  "))
+            {
+                SnapshotJsonSerializer.WriteObject(writer, snapshot);
+                writer.Flush();
+            }
+
+            if (stream.CanSeek)
+            {
+                stream.SetLength(stream.Position);
+            }
+        }
+
         private static BDInfoReportData ReadReport(Stream stream, BDInfoReportFormat format)
         {
             switch (format)
             {
                 case BDInfoReportFormat.Json:
-                    using (var reader = JsonReaderWriterFactory.CreateJsonReader(stream, Encoding.UTF8, XmlDictionaryReaderQuotas.Max, null))
-                    {
-                        return (BDInfoReportData)JsonSerializer.ReadObject(reader);
-                    }
+                    return ReadJsonReport(stream);
 
                 default:
                     using (var reader = XmlReader.Create(stream))
@@ -264,6 +333,78 @@ namespace BDInfo.Reporting
                         return (BDInfoReportData)XmlSerializer.ReadObject(reader);
                     }
             }
+        }
+
+        private static BDInfoReportData ReadJsonReport(Stream stream)
+        {
+            byte[] data;
+            using (var buffer = new MemoryStream())
+            {
+                stream.CopyTo(buffer);
+                data = buffer.ToArray();
+            }
+
+            using (var snapshotStream = new MemoryStream(data))
+            using (var snapshotReader = JsonReaderWriterFactory.CreateJsonReader(snapshotStream, Encoding.UTF8, XmlDictionaryReaderQuotas.Max, null))
+            {
+                try
+                {
+                    var snapshot = (BDInfoSnapshotData)SnapshotJsonSerializer.ReadObject(snapshotReader);
+                    if (IsSnapshotV2(snapshot))
+                    {
+                        return snapshot.Payload;
+                    }
+                }
+                catch (SerializationException)
+                {
+                }
+            }
+
+            using (var reportStream = new MemoryStream(data))
+            using (var reader = JsonReaderWriterFactory.CreateJsonReader(reportStream, Encoding.UTF8, XmlDictionaryReaderQuotas.Max, null))
+            {
+                return (BDInfoReportData)JsonSerializer.ReadObject(reader);
+            }
+        }
+
+        private static bool IsSnapshotV2(BDInfoSnapshotData snapshot)
+        {
+            return snapshot != null &&
+                string.Equals(snapshot.Format, SnapshotFormat, StringComparison.Ordinal) &&
+                snapshot.SchemaVersion == SnapshotSchemaVersion &&
+                string.Equals(snapshot.PayloadKind, SnapshotPayloadKind, StringComparison.Ordinal) &&
+                snapshot.Payload != null;
+        }
+
+        private static BDInfoSnapshotData CreateSnapshot(BDInfoReportData report)
+        {
+            return new BDInfoSnapshotData
+            {
+                Format = SnapshotFormat,
+                SchemaVersion = SnapshotSchemaVersion,
+                PayloadKind = SnapshotPayloadKind,
+                CreatedBy = string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    "BDInfo_clicli {0}",
+                    typeof(BDInfoReportSerializer).Assembly.GetName().Version),
+                CreatedAt = report.CreatedUtc.ToString("o", System.Globalization.CultureInfo.InvariantCulture),
+                Payload = report
+            };
+        }
+
+        private static BDInfoReportData BuildReportData(
+            BDROM bdrom,
+            List<TSPlaylistFile> playlists,
+            ScanBDROMResult scanResult)
+        {
+            return new BDInfoReportData
+            {
+                CreatedUtc = DateTime.UtcNow,
+                Version = typeof(BDInfoReportSerializer).Assembly.GetName().Version?.ToString(),
+                SourcePath = GetSourcePath(bdrom),
+                Disc = BuildDiscData(bdrom, playlists),
+                ScanResult = ConvertScanResult(scanResult)
+            };
         }
 
         public static BDROM CreateBDROM(BDInfoReportData report)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,24 +363,23 @@ Done when:
 
 ### 18. Implement Snapshot v2 Envelope
 
-Status: next.
+Status: done.
 
 Goal: add an explicit snapshot envelope with schema/version metadata.
 
 Scope:
 - Add `format`, `schemaVersion`, `payloadKind`, `createdBy`, `createdAt`, and `payload`.
-- Make compressed JSON the canonical `.bdinfo` snapshot output.
-- Keep raw JSON as a development/debug export if useful.
-- Decide whether XML export remains visible, deprecated, or removed.
+- Add a serializer entry point that writes compressed JSON Snapshot v2 archives.
+- Keep existing CLI and GUI defaults unchanged until their dedicated follow-up items.
 
 Done when:
-- New `.bdinfo` files are versioned compressed JSON snapshots.
+- Snapshot v2 archives are versioned compressed JSON with a deterministic `snapshot.json` entry.
 - Loader identifies Snapshot v2 by envelope fields, not only extension.
 - Round-trip smoke covers Snapshot v2.
 
 ### 19. Update Report Fixtures And Documentation
 
-Status: pending.
+Status: next.
 
 Goal: make tests and user docs match Snapshot v2.
 

--- a/scripts/smoke-report-roundtrip.ps1
+++ b/scripts/smoke-report-roundtrip.ps1
@@ -314,6 +314,28 @@ function Test-ReportLoad([string] $Path) {
     }
 }
 
+function Test-SnapshotV2Archive([string] $Path) {
+    $archive = [IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $entry = $archive.GetEntry('snapshot.json')
+        Assert-True ($null -ne $entry) "Snapshot v2 archive is missing snapshot.json: $Path"
+        $stream = $entry.Open()
+        try {
+            $reader = New-Object IO.StreamReader($stream, [Text.Encoding]::UTF8)
+            $json = $reader.ReadToEnd()
+            Assert-True ($json -match '"format"\s*:\s*"BDInfo_clicli"') "Snapshot v2 format marker was not written."
+            Assert-True ($json -match '"schemaVersion"\s*:\s*2') "Snapshot v2 schema version was not written."
+            Assert-True ($json -match '"payloadKind"\s*:\s*"reportSnapshot"') "Snapshot v2 payload kind was not written."
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
 $buildOutputFullPath = Resolve-FullPath $BuildOutputPath
 $outputFullPath = Resolve-FullPath $OutputPath
 $fixtureFullPath = Resolve-FullPath $FixturePath
@@ -362,6 +384,7 @@ try {
     $savedJsonPath = Join-Path $outputFullPath 'saved-json.bdinfo'
     $savedZipXmlPath = Join-Path $outputFullPath 'saved-xml-compressed.bdinfo'
     $savedZipJsonPath = Join-Path $outputFullPath 'saved-json-compressed.bdinfo'
+    $savedSnapshotV2Path = Join-Path $outputFullPath 'saved-snapshot-v2.bdinfo'
 
     [BDInfo.Reporting.BDInfoReportSerializer]::Save(
         $savedXmlPath,
@@ -391,11 +414,19 @@ try {
         $seedXml.ScanResult,
         [BDInfo.Reporting.BDInfoReportFormat]::Json,
         $true)
+    [BDInfo.Reporting.BDInfoReportSerializer]::SaveSnapshotV2(
+        $savedSnapshotV2Path,
+        $seedXml.BDROM,
+        $seedXml.BDROM.PlaylistFiles.Values,
+        $seedXml.ScanResult,
+        $true)
 
     Test-ReportLoad $savedXmlPath | Out-Null
     Test-ReportLoad $savedJsonPath | Out-Null
     Test-ReportLoad $savedZipXmlPath | Out-Null
     Test-ReportLoad $savedZipJsonPath | Out-Null
+    Test-SnapshotV2Archive $savedSnapshotV2Path
+    Test-ReportLoad $savedSnapshotV2Path | Out-Null
 
     Write-Host "BDInfo report round-trip smoke passed: $outputFullPath"
 }


### PR DESCRIPTION
## Summary

- Add a `BDInfoSnapshotData` envelope for Snapshot v2 with explicit `format`, `schemaVersion`, `payloadKind`, `createdBy`, `createdAt`, and `payload` fields.
- Add `BDInfoReportSerializer.SaveSnapshotV2(...)` to write compressed JSON `.bdinfo` archives with deterministic `snapshot.json` entries.
- Teach report loading to prefer `snapshot.json`, validate Snapshot v2 by envelope fields, and fall back to existing JSON/XML proof-of-concept report shapes.
- Extend the report round-trip smoke to create, inspect, and reload a Snapshot v2 archive.
- Update the roadmap so the CLI/GUI behavior switch remains a separate follow-up from the serializer/envelope work.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Commands run:

```powershell
git diff --check
& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
& .\BDInfo\bin\Release\BDInfo.exe --help
& .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00000 -ChartFormat jpg
```

Real-disc smoke used `THE_AFRICAN_QUEEN` / `00000.MPLS` from `V:\`.

## Risk Notes

- GUI impact: no GUI default/export behavior is changed in this PR.
- CLI impact: no CLI format semantics are changed in this PR; existing XML/JSON/compressed exports were verified by real-disc smoke.
- Report format/backward compatibility impact: adds a new Snapshot v2 load/save path and keeps best-effort fallback for existing JSON/XML POC `.bdinfo` files.

## Release Notes

- Add Snapshot v2 envelope support behind the report serializer API; CLI/GUI default behavior is unchanged pending follow-up PRs.