### PR TITLE
[codex] Align CLI snapshot report semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Before finalizing a PR, verify:
 - GUI launch with no arguments still opens the GUI.
 - GUI launch with a single path argument still opens the GUI and loads that path/report.
 - CLI mode is entered only for explicit CLI usage, such as options or source plus destination.
-- Text, legacy XML `.bdinfo`, legacy JSON `.bdinfo`, compressed legacy `.bdinfo`, and Snapshot v2 `.bdinfo` paths do not overwrite each other unexpectedly.
+- Text, Snapshot v2 `bdinfo`, legacy `bdinfo-json`, legacy `bdinfo-xml`, and compressed legacy paths do not overwrite each other unexpectedly.
 - Exported `.bdinfo` files and committed Snapshot v2 fixtures load back into the GUI and can regenerate reports/charts without the original disc.
 - README/help text matches the actual CLI behavior.
 

--- a/BDInfo/CliArgumentParser.cs
+++ b/BDInfo/CliArgumentParser.cs
@@ -9,7 +9,8 @@ namespace BDInfo
     {
         Text,
         Bdinfo,
-        BdinfoJson
+        BdinfoJson,
+        BdinfoXml
     }
 
     internal sealed class CliOptions
@@ -302,8 +303,10 @@ namespace BDInfo
                 case "text":
                     return ReportFormat.Text;
                 case "bdinfo":
-                case "bdinfo-xml":
                     return ReportFormat.Bdinfo;
+                case "bdinfo-xml":
+                case "xml":
+                    return ReportFormat.BdinfoXml;
                 case "bdinfo-json":
                 case "json":
                     return ReportFormat.BdinfoJson;

--- a/BDInfo/CliReportWriter.cs
+++ b/BDInfo/CliReportWriter.cs
@@ -46,6 +46,13 @@ namespace BDInfo
 
             if (formats.Contains(ReportFormat.Bdinfo))
             {
+                string reportPath = Path.Combine(destination, fileNames.SnapshotReportFileName);
+                BDInfoReportSerializer.SaveSnapshotV2(reportPath, bdrom, playlists, scanResult, compress: true);
+                writtenPaths.Add(reportPath);
+            }
+
+            if (formats.Contains(ReportFormat.BdinfoXml))
+            {
                 string reportPath = Path.Combine(destination, fileNames.XmlReportFileName);
                 BDInfoReportSerializer.Save(reportPath, bdrom, playlists, scanResult, BDInfoReportFormat.Xml, compress);
                 writtenPaths.Add(reportPath);
@@ -64,25 +71,26 @@ namespace BDInfo
             string sanitizedVolumeLabel = ReportFileNameHelper.CreateSafeBaseName(volumeLabel, "UNKNOWN", "BDINFO");
 
             string textFileName = ToolBox.GetSafeFileName(string.Format(CultureInfo.InvariantCulture, "BDINFO.{0}.txt", sanitizedVolumeLabel));
-            string xmlFileName = sanitizedVolumeLabel + ".bdinfo";
-            string jsonFileName = formats.Contains(ReportFormat.Bdinfo)
-                ? sanitizedVolumeLabel + ".json.bdinfo"
-                : sanitizedVolumeLabel + ".bdinfo";
+            string snapshotFileName = sanitizedVolumeLabel + ".bdinfo";
+            string xmlFileName = sanitizedVolumeLabel + ".xml.bdinfo";
+            string jsonFileName = sanitizedVolumeLabel + ".json.bdinfo";
 
-            return new CliReportFileNames(textFileName, xmlFileName, jsonFileName);
+            return new CliReportFileNames(textFileName, snapshotFileName, xmlFileName, jsonFileName);
         }
     }
 
     internal sealed class CliReportFileNames
     {
-        public CliReportFileNames(string textFileName, string xmlReportFileName, string jsonReportFileName)
+        public CliReportFileNames(string textFileName, string snapshotReportFileName, string xmlReportFileName, string jsonReportFileName)
         {
             TextFileName = textFileName;
+            SnapshotReportFileName = snapshotReportFileName;
             XmlReportFileName = xmlReportFileName;
             JsonReportFileName = jsonReportFileName;
         }
 
         public string TextFileName { get; private set; }
+        public string SnapshotReportFileName { get; private set; }
         public string XmlReportFileName { get; private set; }
         public string JsonReportFileName { get; private set; }
     }

--- a/BDInfo/ConsoleRunner.cs
+++ b/BDInfo/ConsoleRunner.cs
@@ -1334,8 +1334,9 @@ namespace BDInfo
             Console.WriteLine("  -w, --whole                Scan whole disc - every playlist.");
             Console.WriteLine("  -v, --version              Print the version.");
             Console.WriteLine("  -c, --charts[=FORMAT]      Save all charts as image (png by default; also jpg, bmp, gif, tiff).");
-            Console.WriteLine("  -r, --report               Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.");
-            Console.WriteLine("  -z, --compress             Compress generated .bdinfo reports using ZIP.");
+            Console.WriteLine("  -r, --report               Choose report formats (txt, bdinfo, bdinfo-json, bdinfo-xml). Use commas for multiple.");
+            Console.WriteLine("                             bdinfo writes Snapshot v2 compressed JSON; bdinfo-json/xml are legacy exports.");
+            Console.WriteLine("  -z, --compress             Compress legacy bdinfo-json/bdinfo-xml reports using ZIP.");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,18 +36,20 @@ Options:
   -w, --whole                Scan whole disc - every playlist.
   -v, --version              Print the version.
   -c, --charts[=FORMAT]      Save all charts as image (png by default; also jpg, bmp, gif, tiff).
-  -r, --report               Choose report formats (txt, bdinfo, bdinfo-json). Use commas for multiple.
-  -z, --compress             Compress generated .bdinfo reports using ZIP.
+  -r, --report               Choose report formats (txt, bdinfo, bdinfo-json, bdinfo-xml). Use commas for multiple.
+                             bdinfo writes Snapshot v2 compressed JSON; bdinfo-json/xml are legacy exports.
+  -z, --compress             Compress legacy bdinfo-json/bdinfo-xml reports using ZIP.
 ```
 
 ---
 
 ### 2) Export & reload reports (.bdinfo)
 You can now **export a BDInfo report to a single `.bdinfo` file** and later **open it in the GUI** to browse playlists, streams, and **see charts as if you just scanned the disc**.
-Current CLI and GUI exports still expose the legacy proof-of-concept **JSON** and **XML** snapshot formats. Snapshot v2 support exists in the serializer/loader and is the canonical compressed JSON direction for follow-up CLI/GUI export changes. The GUI export dialog also supports a plain text report (`.txt`).
+CLI `-r bdinfo` now writes Snapshot v2 compressed JSON. The legacy proof-of-concept **JSON** and **XML** snapshot formats remain available through explicit CLI format names and the current GUI export dialog. The GUI export dialog also supports a plain text report (`.txt`).
 
 - **Export locations**: available in **GUI** (button **“Export Report…”**) and in the **CLI** (use `-r` / `--report`).
 - **GUI export defaults**: the suggested `.bdinfo` filename is based on the disc volume label. Empty or fully unsafe labels fall back to `BDINFO.bdinfo`.
+- **CLI export formats**: `txt`, `bdinfo` (Snapshot v2 compressed JSON), `bdinfo-json` (legacy JSON), and `bdinfo-xml` (legacy XML).
 - **GUI export formats today**: **XML `.bdinfo`**, **JSON `.bdinfo`**, **compressed XML `.bdinfo`**, **compressed JSON `.bdinfo`**, and **text `.txt`** are available from the export dialog.
 - **Open/reload**: supported **only in the GUI**. Click **Load Report...** and select a previously saved `.bdinfo` file. BDInfo detects Snapshot v2 compressed JSON, legacy JSON/XML, and ZIP-compressed legacy `.bdinfo` reports.
 - **Use case**: scan once on a server/headless box, then send the `.bdinfo` to someone who can open it in the GUI and review details/charts without access to the disc.
@@ -128,9 +130,9 @@ Common options:
 - `-l, --list` – list playlists in `<BD_PATH>`
 - `-m, --mpls=VALUE` – comma‑separated playlist IDs to scan (e.g., `-m 800,801`)
 - `-w, --whole` – scan **all** playlists
-- `-r, --report` – choose report formats: `txt`, `bdinfo`, `bdinfo-json` (comma‑separate for multiple)
+- `-r, --report` – choose report formats: `txt`, `bdinfo`, `bdinfo-json`, `bdinfo-xml` (comma‑separate for multiple)
 - `-c, --charts[=FORMAT]` – save bitrate charts as images (default **png**; also `jpg`, `bmp`, `gif`, `tiff`)
-- `-z, --compress` – compress generated `.bdinfo` reports using ZIP
+- `-z, --compress` – compress legacy `bdinfo-json` / `bdinfo-xml` reports using ZIP; `bdinfo` is always compressed Snapshot v2
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,7 +395,7 @@ Done when:
 
 ### 20. Align CLI Snapshot Semantics
 
-Status: next.
+Status: done.
 
 Goal: make CLI report format names match the Snapshot v2 policy.
 
@@ -412,7 +412,7 @@ Done when:
 
 ### 21. Align GUI Export Semantics
 
-Status: pending.
+Status: next.
 
 Goal: make GUI export defaults match the Snapshot v2 policy.
 

--- a/docs/REPORT_FORMATS.md
+++ b/docs/REPORT_FORMATS.md
@@ -22,14 +22,14 @@ Policy:
 The `.bdinfo` file is an application snapshot, not a public stable API.
 
 Current user-visible behavior during the Snapshot v2 transition:
-- XML `.bdinfo` and JSON `.bdinfo` can both be exported from the current CLI/GUI paths.
-- ZIP-compressed XML/JSON `.bdinfo` can both be exported from the current CLI/GUI paths.
-- Snapshot v2 compressed JSON is supported by the serializer/loader and covered by fixtures.
+- CLI `-r bdinfo` writes Snapshot v2 compressed JSON `.bdinfo`.
+- CLI `-r bdinfo-json` and `-r bdinfo-xml` write legacy proof-of-concept JSON/XML snapshots.
+- The GUI export dialog still exposes legacy XML/JSON snapshot options until the GUI follow-up is completed.
 - The GUI loader auto-detects Snapshot v2, JSON, XML, and ZIP-compressed `.bdinfo` files.
 
 Target policy:
 - The canonical snapshot format is compressed JSON `.bdinfo`.
-- CLI `-r bdinfo` should mean canonical compressed JSON `.bdinfo`.
+- CLI `-r bdinfo` means canonical compressed JSON `.bdinfo`.
 - GUI text export remains the default human-readable export.
 - Raw JSON can remain available as a development/debug export.
 - XML is deprecated. Do not extend XML unless a specific compatibility need is identified.

--- a/docs/REPORT_PIPELINE_AUDIT.md
+++ b/docs/REPORT_PIPELINE_AUDIT.md
@@ -62,15 +62,15 @@ Files:
 
 Current behavior:
 - Default CLI report format is text.
-- `-r bdinfo` and `-r bdinfo-xml` mean XML `.bdinfo`.
-- `-r bdinfo-json` and `-r json` mean JSON `.bdinfo`.
-- `-z/--compress` controls compression for XML and JSON snapshot formats.
-- When XML and JSON are both requested, JSON gets `.json.bdinfo` to avoid overwriting XML `.bdinfo`.
+- `-r bdinfo` means Snapshot v2 compressed JSON `.bdinfo`.
+- `-r bdinfo-json` and `-r json` mean legacy JSON `.json.bdinfo`.
+- `-r bdinfo-xml` and `-r xml` mean legacy XML `.xml.bdinfo`.
+- `-z/--compress` controls compression for legacy XML and JSON snapshot formats; Snapshot v2 is always compressed.
+- Snapshot v2, legacy XML, and legacy JSON use distinct filenames when requested together.
 
-Policy gap:
-- Target policy says CLI `-r bdinfo` should mean canonical compressed JSON `.bdinfo`.
-- That means `ReportFormat.Bdinfo` should stop meaning XML once Snapshot v2 is implemented.
-- Compression should become the default for canonical `bdinfo`; raw JSON should be explicit debug/development output.
+Policy status:
+- CLI `bdinfo` now matches the canonical compressed JSON policy.
+- Raw JSON and XML remain explicit legacy/development exports.
 
 ### GUI Export And Load
 

--- a/scripts/smoke-hdr10plus-local.ps1
+++ b/scripts/smoke-hdr10plus-local.ps1
@@ -3,13 +3,14 @@ param(
     [string] $SourcePath = 'V:\',
     [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_hdr10plus_local'),
     [string] $Playlist = '00800',
-    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
+    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json,bdinfo-xml',
     [string] $ChartFormat = 'jpg',
     [switch] $SkipCharts,
     [switch] $KeepOutput
 )
 
 $ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Resolve-FullPath([string] $Path) {
     $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
@@ -34,9 +35,49 @@ function Assert-FileContainsHdr10Plus([string] $Path, [string] $Description) {
         throw "$Description was not created: $Path"
     }
 
-    if ((Get-Content -LiteralPath $Path -Raw) -notmatch 'HDR10\+') {
+    if ((Get-ReportSearchText $Path) -notmatch 'HDR10\+') {
         throw "$Description does not contain HDR10+: $Path"
     }
+}
+
+function Get-ReportSearchText([string] $Path) {
+    $stream = [IO.File]::OpenRead($Path)
+    try {
+        $first = $stream.ReadByte()
+        $second = $stream.ReadByte()
+    }
+    finally {
+        $stream.Dispose()
+    }
+
+    if ($first -eq [byte][char]'P' -and $second -eq [byte][char]'K') {
+        $archive = [IO.Compression.ZipFile]::OpenRead($Path)
+        try {
+            $text = New-Object Text.StringBuilder
+            foreach ($entry in $archive.Entries) {
+                $entryStream = $entry.Open()
+                try {
+                    $reader = New-Object IO.StreamReader($entryStream, [Text.Encoding]::UTF8)
+                    try {
+                        [void] $text.AppendLine($reader.ReadToEnd())
+                    }
+                    finally {
+                        $reader.Dispose()
+                    }
+                }
+                finally {
+                    $entryStream.Dispose()
+                }
+            }
+
+            return $text.ToString()
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+
+    Get-Content -LiteralPath $Path -Raw
 }
 
 function Get-ReportFile([string] $Directory, [string] $Format) {
@@ -44,13 +85,14 @@ function Get-ReportFile([string] $Directory, [string] $Format) {
         'txt' { '*.txt' }
         'bdinfo' { '*.bdinfo' }
         'bdinfo-json' { '*.json.bdinfo' }
+        'bdinfo-xml' { '*.xml.bdinfo' }
         default { throw "Unsupported report format in smoke script: $Format" }
     }
 
     $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
 
     if ($Format -eq 'bdinfo') {
-        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' -and $_.Name -notlike '*.xml.bdinfo' }
     }
 
     $files | Select-Object -First 1

--- a/scripts/smoke-hdr10plus-swap-local.ps1
+++ b/scripts/smoke-hdr10plus-swap-local.ps1
@@ -5,7 +5,7 @@ param(
     [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_hdr10plus_swap'),
     [string] $FirstPlaylist = '00800',
     [string] $SecondPlaylist,
-    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json',
+    [string] $ReportFormats = 'txt,bdinfo,bdinfo-json,bdinfo-xml',
     [string] $SwapReadySignalPath,
     [string] $DiscReadySignalPath,
     [int] $DiscReadyPollSeconds = 2,
@@ -16,6 +16,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Resolve-FullPath([string] $Path) {
     $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
@@ -83,8 +84,47 @@ function Assert-DirectoryExists([string] $Path, [string] $Description) {
 }
 
 function Test-FileContainsHdr10Plus([string] $Path) {
-    $match = Select-String -LiteralPath $Path -SimpleMatch 'HDR10+' -List -ErrorAction SilentlyContinue
-    $null -ne $match
+    (Get-ReportSearchText $Path) -match 'HDR10\+'
+}
+
+function Get-ReportSearchText([string] $Path) {
+    $stream = [IO.File]::OpenRead($Path)
+    try {
+        $first = $stream.ReadByte()
+        $second = $stream.ReadByte()
+    }
+    finally {
+        $stream.Dispose()
+    }
+
+    if ($first -eq [byte][char]'P' -and $second -eq [byte][char]'K') {
+        $archive = [IO.Compression.ZipFile]::OpenRead($Path)
+        try {
+            $text = New-Object Text.StringBuilder
+            foreach ($entry in $archive.Entries) {
+                $entryStream = $entry.Open()
+                try {
+                    $reader = New-Object IO.StreamReader($entryStream, [Text.Encoding]::UTF8)
+                    try {
+                        [void] $text.AppendLine($reader.ReadToEnd())
+                    }
+                    finally {
+                        $reader.Dispose()
+                    }
+                }
+                finally {
+                    $entryStream.Dispose()
+                }
+            }
+
+            return $text.ToString()
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+
+    Get-Content -LiteralPath $Path -Raw
 }
 
 function Get-ReportFile([string] $Directory, [string] $Format) {
@@ -92,13 +132,14 @@ function Get-ReportFile([string] $Directory, [string] $Format) {
         'txt' { '*.txt' }
         'bdinfo' { '*.bdinfo' }
         'bdinfo-json' { '*.json.bdinfo' }
+        'bdinfo-xml' { '*.xml.bdinfo' }
         default { throw "Unsupported report format in smoke script: $Format" }
     }
 
     $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
 
     if ($Format -eq 'bdinfo') {
-        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' -and $_.Name -notlike '*.xml.bdinfo' }
     }
 
     $files | Select-Object -First 1

--- a/scripts/smoke-local.ps1
+++ b/scripts/smoke-local.ps1
@@ -3,8 +3,8 @@ param(
     [string] $SourcePath = 'V:\',
     [string] $OutputPath = (Join-Path $PSScriptRoot '..\tmp_smoke_local'),
     [string] $Playlist = '00107',
-    [string] $PlainReportFormats = 'txt,bdinfo,bdinfo-json',
-    [string] $CompressedReportFormats = 'bdinfo,bdinfo-json',
+    [string] $PlainReportFormats = 'txt,bdinfo,bdinfo-json,bdinfo-xml',
+    [string] $CompressedReportFormats = 'bdinfo,bdinfo-json,bdinfo-xml',
     [string] $ChartFormat = 'jpg',
     [switch] $SkipCharts,
     [switch] $KeepOutput
@@ -33,15 +33,16 @@ function Assert-DirectoryExists([string] $Path, [string] $Description) {
 function Get-ExpectedReportPath([string] $Directory, [string] $Format, [bool] $Compressed) {
     $pattern = switch ($Format) {
         'txt' { '*.txt' }
-        'bdinfo' { if ($Compressed) { '*.bdinfo' } else { '*.bdinfo' } }
+        'bdinfo' { '*.bdinfo' }
         'bdinfo-json' { '*.json.bdinfo' }
+        'bdinfo-xml' { '*.xml.bdinfo' }
         default { throw "Unsupported report format in smoke script: $Format" }
     }
 
     $files = Get-ChildItem -LiteralPath $Directory -Filter $pattern -File -ErrorAction SilentlyContinue
 
     if ($Format -eq 'bdinfo') {
-        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' }
+        $files = $files | Where-Object { $_.Name -notlike '*.json.bdinfo' -and $_.Name -notlike '*.xml.bdinfo' }
     }
 
     $files | Select-Object -First 1
@@ -56,7 +57,7 @@ function Assert-ReportFormats([string] $Directory, [string] $Formats, [bool] $Co
             throw "Expected $format report was not created in $Directory."
         }
 
-        if ($Compressed -and $format -ne 'txt') {
+        if (($Compressed -and $format -ne 'txt') -or $format -eq 'bdinfo') {
             $stream = [IO.File]::OpenRead($file.FullName)
             try {
                 $first = $stream.ReadByte()


### PR DESCRIPTION
## Summary

- Change CLI `-r bdinfo` to write canonical Snapshot v2 compressed JSON `.bdinfo` archives.
- Keep legacy raw/development exports explicit as `bdinfo-json` (`*.json.bdinfo`) and `bdinfo-xml` (`*.xml.bdinfo`).
- Update CLI help, README, report policy/audit docs, roadmap status, and smoke scripts for the new names and compression semantics.
- Update local/HDR smoke helpers so ZIP Snapshot v2 reports can be inspected when checking HDR10+ labels.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Commands run:

```powershell
git diff --check
& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
& .\BDInfo\bin\Release\BDInfo.exe --help
& .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00000 -ChartFormat jpg
[scriptblock]::Create((Get-Content -LiteralPath '.\scripts\smoke-hdr10plus-local.ps1' -Raw)) | Out-Null
[scriptblock]::Create((Get-Content -LiteralPath '.\scripts\smoke-hdr10plus-swap-local.ps1' -Raw)) | Out-Null
```

Real-disc smoke used `THE_AFRICAN_QUEEN` / `00000.MPLS` from `V:\` and verified separate Snapshot v2 `.bdinfo`, legacy `.json.bdinfo`, and legacy `.xml.bdinfo` outputs.

## Risk Notes

- GUI impact: no GUI export defaults are changed in this PR.
- CLI impact: intentional behavior change: `-r bdinfo` now means Snapshot v2 compressed JSON, while legacy XML requires `bdinfo-xml`.
- Report format/backward compatibility impact: legacy XML/JSON load remains best-effort; legacy CLI exports remain available under explicit names and no longer overwrite canonical `.bdinfo`.

## Release Notes

- CLI `-r bdinfo` now writes canonical Snapshot v2 compressed JSON `.bdinfo`; use `bdinfo-json` or `bdinfo-xml` for legacy snapshot exports.