### PR TITLE
[codex] Align GUI report export defaults

### DIFF
--- a/BDInfo/FormReport.cs
+++ b/BDInfo/FormReport.cs
@@ -1159,18 +1159,19 @@ namespace BDInfo
                 return;
             }
 
-            string defaultName = ReportFileNameHelper.CreateGuiDefaultReportFileName(ReportBDROM.VolumeLabel);
+            string defaultName = ReportFileNameHelper.CreateGuiDefaultTextReportFileName(ReportBDROM.VolumeLabel);
 
             using (SaveFileDialog dialog = new SaveFileDialog())
             {
                 dialog.Filter = string.Join("|",
-                    "BDInfo Report (XML) (*.bdinfo)", "*.bdinfo",
-                    "BDInfo Report (JSON) (*.bdinfo)", "*.bdinfo",
-                    "BDInfo Report (XML, compressed) (*.bdinfo)", "*.bdinfo",
-                    "BDInfo Report (JSON, compressed) (*.bdinfo)", "*.bdinfo",
                     "BDInfo Report (Text) (*.txt)", "*.txt",
+                    "BDInfo Snapshot v2 (*.bdinfo)", "*.bdinfo",
+                    "BDInfo Report (legacy JSON) (*.json.bdinfo)", "*.json.bdinfo",
+                    "BDInfo Report (legacy JSON, compressed) (*.json.bdinfo)", "*.json.bdinfo",
+                    "BDInfo Report (legacy XML) (*.xml.bdinfo)", "*.xml.bdinfo",
+                    "BDInfo Report (legacy XML, compressed) (*.xml.bdinfo)", "*.xml.bdinfo",
                     "All files (*.*)", "*.*");
-                dialog.DefaultExt = "bdinfo";
+                dialog.DefaultExt = "txt";
                 dialog.FileName = defaultName;
 
                 if (dialog.ShowDialog(this) == DialogResult.OK)
@@ -1193,13 +1194,26 @@ namespace BDInfo
                             return;
                         }
 
-                        BDInfoReportSerializer.Save(
-                            exportOptions.FileName,
-                            ReportBDROM,
-                            ReportPlaylists,
-                            ReportScanResult,
-                            exportOptions.Format,
-                            exportOptions.Compress);
+                        if (exportOptions.IsSnapshot)
+                        {
+                            BDInfoReportSerializer.SaveSnapshotV2(
+                                exportOptions.FileName,
+                                ReportBDROM,
+                                ReportPlaylists,
+                                ReportScanResult,
+                                compress: true);
+                        }
+                        else
+                        {
+                            BDInfoReportSerializer.Save(
+                                exportOptions.FileName,
+                                ReportBDROM,
+                                ReportPlaylists,
+                                ReportScanResult,
+                                exportOptions.Format,
+                                exportOptions.Compress);
+                        }
+
                         MessageBox.Show(this,
                             "Report exported successfully.",
                             "BDInfo",

--- a/BDInfo/GuiReportExportSelection.cs
+++ b/BDInfo/GuiReportExportSelection.cs
@@ -11,27 +11,67 @@ namespace BDInfo
             switch (filterIndex)
             {
                 case 2:
-                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Json, compress: false);
+                    return GuiReportExportOptions.CreateSnapshot(GetFileNameWithSuffix(fileName, ".bdinfo"));
                 case 3:
-                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Xml, compress: true);
+                    return GuiReportExportOptions.CreateReport(GetFileNameWithSuffix(fileName, ".json.bdinfo"), BDInfoReportFormat.Json, compress: false);
                 case 4:
-                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Json, compress: true);
+                    return GuiReportExportOptions.CreateReport(GetFileNameWithSuffix(fileName, ".json.bdinfo"), BDInfoReportFormat.Json, compress: true);
                 case 5:
-                    return GuiReportExportOptions.CreateText(GetTextFileName(fileName));
+                    return GuiReportExportOptions.CreateReport(GetFileNameWithSuffix(fileName, ".xml.bdinfo"), BDInfoReportFormat.Xml, compress: false);
+                case 6:
+                    return GuiReportExportOptions.CreateReport(GetFileNameWithSuffix(fileName, ".xml.bdinfo"), BDInfoReportFormat.Xml, compress: true);
+                case 7:
+                    return CreateFromFileName(fileName);
                 case 1:
                 default:
-                    return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Xml, compress: false);
+                    return GuiReportExportOptions.CreateText(GetFileNameWithSuffix(fileName, ".txt"));
             }
         }
 
-        private static string GetTextFileName(string fileName)
+        private static GuiReportExportOptions CreateFromFileName(string fileName)
         {
-            if (!string.Equals(Path.GetExtension(fileName), ".txt", StringComparison.OrdinalIgnoreCase))
+            if (fileName.EndsWith(".json.bdinfo", StringComparison.OrdinalIgnoreCase))
             {
-                return Path.ChangeExtension(fileName, ".txt");
+                return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Json, compress: false);
             }
 
-            return fileName;
+            if (fileName.EndsWith(".xml.bdinfo", StringComparison.OrdinalIgnoreCase))
+            {
+                return GuiReportExportOptions.CreateReport(fileName, BDInfoReportFormat.Xml, compress: false);
+            }
+
+            if (fileName.EndsWith(".bdinfo", StringComparison.OrdinalIgnoreCase))
+            {
+                return GuiReportExportOptions.CreateSnapshot(fileName);
+            }
+
+            return GuiReportExportOptions.CreateText(GetFileNameWithSuffix(fileName, ".txt"));
+        }
+
+        private static string GetFileNameWithSuffix(string fileName, string suffix)
+        {
+            string directory = Path.GetDirectoryName(fileName);
+            string baseName = Path.GetFileName(fileName);
+
+            baseName = RemoveKnownSuffix(baseName, ".json.bdinfo");
+            baseName = RemoveKnownSuffix(baseName, ".xml.bdinfo");
+            baseName = RemoveKnownSuffix(baseName, ".bdinfo");
+            baseName = RemoveKnownSuffix(baseName, ".txt");
+
+            string normalized = baseName + suffix;
+            return string.IsNullOrEmpty(directory)
+                ? normalized
+                : Path.Combine(directory, normalized);
+        }
+
+        private static string RemoveKnownSuffix(string value, string suffix)
+        {
+            if (value != null && value.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return value.Substring(0, value.Length - suffix.Length);
+            }
+
+            return value;
         }
     }
 
@@ -42,6 +82,7 @@ namespace BDInfo
         }
 
         public bool IsText { get; private set; }
+        public bool IsSnapshot { get; private set; }
         public string FileName { get; private set; }
         public BDInfoReportFormat Format { get; private set; }
         public bool Compress { get; private set; }
@@ -51,9 +92,22 @@ namespace BDInfo
             return new GuiReportExportOptions
             {
                 IsText = false,
+                IsSnapshot = false,
                 FileName = fileName,
                 Format = format,
                 Compress = compress
+            };
+        }
+
+        public static GuiReportExportOptions CreateSnapshot(string fileName)
+        {
+            return new GuiReportExportOptions
+            {
+                IsText = false,
+                IsSnapshot = true,
+                FileName = fileName,
+                Format = BDInfoReportFormat.Json,
+                Compress = true
             };
         }
 
@@ -62,6 +116,7 @@ namespace BDInfo
             return new GuiReportExportOptions
             {
                 IsText = true,
+                IsSnapshot = false,
                 FileName = fileName,
                 Format = BDInfoReportFormat.Xml,
                 Compress = false

--- a/BDInfo/ReportFileNameHelper.cs
+++ b/BDInfo/ReportFileNameHelper.cs
@@ -23,5 +23,10 @@ namespace BDInfo
         {
             return CreateSafeBaseName(volumeLabel, "BDINFO", "BDINFO") + ".bdinfo";
         }
+
+        public static string CreateGuiDefaultTextReportFileName(string volumeLabel)
+        {
+            return CreateSafeBaseName(volumeLabel, "BDINFO", "BDINFO") + ".txt";
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ You can now **export a BDInfo report to a single `.bdinfo` file** and later **op
 CLI `-r bdinfo` now writes Snapshot v2 compressed JSON. The legacy proof-of-concept **JSON** and **XML** snapshot formats remain available through explicit CLI format names and the current GUI export dialog. The GUI export dialog also supports a plain text report (`.txt`).
 
 - **Export locations**: available in **GUI** (button **“Export Report…”**) and in the **CLI** (use `-r` / `--report`).
-- **GUI export defaults**: the suggested `.bdinfo` filename is based on the disc volume label. Empty or fully unsafe labels fall back to `BDINFO.bdinfo`.
+- **GUI export defaults**: text `.txt` is the default export. The suggested filename is based on the disc volume label; empty or fully unsafe labels fall back to `BDINFO.txt`.
 - **CLI export formats**: `txt`, `bdinfo` (Snapshot v2 compressed JSON), `bdinfo-json` (legacy JSON), and `bdinfo-xml` (legacy XML).
-- **GUI export formats today**: **XML `.bdinfo`**, **JSON `.bdinfo`**, **compressed XML `.bdinfo`**, **compressed JSON `.bdinfo`**, and **text `.txt`** are available from the export dialog.
+- **GUI export formats**: **text `.txt`**, **Snapshot v2 `.bdinfo`**, legacy **JSON `.json.bdinfo`**, and legacy **XML `.xml.bdinfo`** are available from the export dialog. Legacy JSON/XML also have compressed variants.
 - **Open/reload**: supported **only in the GUI**. Click **Load Report...** and select a previously saved `.bdinfo` file. BDInfo detects Snapshot v2 compressed JSON, legacy JSON/XML, and ZIP-compressed legacy `.bdinfo` reports.
 - **Use case**: scan once on a server/headless box, then send the `.bdinfo` to someone who can open it in the GUI and review details/charts without access to the disc.
 
@@ -122,7 +122,7 @@ Codex/agent operating rules live in [`AGENTS.md`](AGENTS.md). Pull requests shou
 1. Launch **BDInfo.exe**.
 2. Select a disc or BDMV folder to scan.
 3. Inspect playlists, streams, and bitrates.
-4. Click **Export Report…** in the report viewer to save the current legacy **XML `.bdinfo`**, **JSON `.bdinfo`**, compressed `.bdinfo`, or text `.txt`.
+4. Click **Export Report…** in the report viewer to save text `.txt`, Snapshot v2 `.bdinfo`, or explicit legacy JSON/XML snapshots.
 5. Later, click **Load Report...** to load a saved Snapshot v2, legacy XML/JSON, or compressed `.bdinfo` and review charts without rescanning.
 
 ### CLI (headless)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,7 +412,7 @@ Done when:
 
 ### 21. Align GUI Export Semantics
 
-Status: next.
+Status: done.
 
 Goal: make GUI export defaults match the Snapshot v2 policy.
 

--- a/docs/REPORT_FORMATS.md
+++ b/docs/REPORT_FORMATS.md
@@ -24,13 +24,13 @@ The `.bdinfo` file is an application snapshot, not a public stable API.
 Current user-visible behavior during the Snapshot v2 transition:
 - CLI `-r bdinfo` writes Snapshot v2 compressed JSON `.bdinfo`.
 - CLI `-r bdinfo-json` and `-r bdinfo-xml` write legacy proof-of-concept JSON/XML snapshots.
-- The GUI export dialog still exposes legacy XML/JSON snapshot options until the GUI follow-up is completed.
+- The GUI export dialog defaults to text, offers Snapshot v2 `.bdinfo`, and keeps legacy JSON/XML under explicit labels.
 - The GUI loader auto-detects Snapshot v2, JSON, XML, and ZIP-compressed `.bdinfo` files.
 
 Target policy:
 - The canonical snapshot format is compressed JSON `.bdinfo`.
 - CLI `-r bdinfo` means canonical compressed JSON `.bdinfo`.
-- GUI text export remains the default human-readable export.
+- GUI text export is the default human-readable export.
 - Raw JSON can remain available as a development/debug export.
 - XML is deprecated. Do not extend XML unless a specific compatibility need is identified.
 - Support for old proof-of-concept XML/JSON `.bdinfo` files is best effort only; do not block Snapshot v2 on preserving old POC shapes.

--- a/docs/REPORT_PIPELINE_AUDIT.md
+++ b/docs/REPORT_PIPELINE_AUDIT.md
@@ -80,15 +80,16 @@ Files:
 - `BDInfo/GuiReportLoader.cs`
 
 Current behavior:
-- GUI export dialog first filter is XML `.bdinfo`.
-- GUI text export is filter 5, not the default.
-- GUI default extension is `.bdinfo`.
+- GUI export dialog first filter is text `.txt`.
+- GUI Snapshot v2 export is available as compressed JSON `.bdinfo`.
+- Legacy JSON/XML exports are available under explicit legacy labels and distinct `.json.bdinfo` / `.xml.bdinfo` suffixes.
+- GUI default extension is `.txt`.
 - GUI loader accepts any `.bdinfo`, then delegates format detection to `BDInfoReportSerializer.Load`.
 
-Policy gap:
-- Target policy says GUI default export should be text.
-- Snapshot export should still be available, but canonical Snapshot v2 should be compressed JSON.
-- XML export should be deprecated, hidden, or removed as a deliberate follow-up decision.
+Policy status:
+- GUI default export is text.
+- Snapshot export uses canonical Snapshot v2 compressed JSON.
+- XML remains visible only as an explicit legacy export.
 
 ### Charts
 


### PR DESCRIPTION
## Summary

- Make GUI report export default to text `.txt` with a `.txt` default filename.
- Add GUI Snapshot v2 `.bdinfo` export using `SaveSnapshotV2(...)` as the preferred snapshot option.
- Keep legacy JSON/XML GUI exports under explicit labels and distinct `.json.bdinfo` / `.xml.bdinfo` suffixes, with compressed variants still available.
- Normalize GUI export filenames when switching filters and infer sensible behavior from `All files` by extension.
- Update README, report format policy/audit docs, and roadmap status.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [x] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Commands run:

```powershell
git diff --check
& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
& .\BDInfo\bin\Release\BDInfo.exe --help
& .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-local.ps1 -BuildOutputPath .\BDInfo\bin\Release -SourcePath V:\ -Playlist 00000 -ChartFormat jpg
```

Additional local reflection smoke verified GUI export selection mapping:

- filter 1 -> text `.txt`
- filter 2 -> Snapshot v2 `.bdinfo`
- filters 3/4 -> legacy JSON `.json.bdinfo`
- filters 5/6 -> legacy XML `.xml.bdinfo`
- `All files` infers from `.txt`, `.bdinfo`, `.json.bdinfo`, and `.xml.bdinfo`

Real-disc smoke used `THE_AFRICAN_QUEEN` / `00000.MPLS` from `V:\`.

## Risk Notes

- GUI impact: intentional behavior change; text is now the default export and Snapshot v2 is the preferred `.bdinfo` option.
- CLI impact: no CLI behavior change in this PR.
- Report format/backward compatibility impact: legacy GUI JSON/XML exports remain available under explicit labels; Snapshot v2 `.bdinfo` is now available from GUI export.

## Release Notes

- GUI report export now defaults to text and offers Snapshot v2 `.bdinfo`; legacy JSON/XML exports remain available under explicit legacy labels.