### PR TITLE
[codex] Add GUI smoke checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ git diff --check
 & .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
 ```
 
+For GUI launch/export work, also run:
+
+```powershell
+& .\scripts\smoke-gui-launch.ps1 -BuildOutputPath .\BDInfo\bin\Release
+```
+
+Use `docs/MANUAL_GUI_SMOKE.md` for the remaining visual export/load/chart checks.
+
 For CLI/report/export changes, also run a real-disc smoke when a decrypted BD root is available, for example `V:\`:
 
 ```powershell

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -433,7 +433,7 @@ This phase starts after Snapshot v2 is available from both CLI and GUI. The goal
 
 ### 22. Manual GUI Snapshot v2 Smoke
 
-Status: next.
+Status: in progress.
 
 Goal: verify the interactive GUI workflows that local CLI smoke cannot fully cover.
 
@@ -448,6 +448,10 @@ Done when:
 - GUI default export is visibly text `.txt`.
 - GUI Snapshot v2 export loads back and regenerates the report/chart views.
 - Legacy JSON/XML exports are still reachable under explicit legacy labels.
+
+Progress:
+- Added `scripts/smoke-gui-launch.ps1` for no-argument and single Snapshot v2 `.bdinfo` GUI launch checks.
+- Added `docs/MANUAL_GUI_SMOKE.md` for the remaining visual export/load/chart checklist.
 
 ### 23. Snapshot v2 Release Prep
 

--- a/docs/MANUAL_GUI_SMOKE.md
+++ b/docs/MANUAL_GUI_SMOKE.md
@@ -1,0 +1,49 @@
+# Manual GUI Smoke
+
+Use this checklist for GUI behavior that cannot be fully validated by command-line smoke scripts.
+
+## Preconditions
+
+- Build `BDInfo.sln` in Release.
+- Use a decrypted Blu-ray root when scanning a real disc, for example `V:\`.
+- Keep the tested build output path and disc/playlist IDs in the PR notes.
+
+## Automated GUI Launch Smoke
+
+Run this first to verify that the GUI starts without arguments and with a committed Snapshot v2 `.bdinfo` fixture:
+
+```powershell
+& .\scripts\smoke-gui-launch.ps1 -BuildOutputPath .\BDInfo\bin\Release
+```
+
+This smoke only checks that the main window appears and stays alive briefly. It does not verify visual layout, export dialogs, chart rendering, or user interaction.
+
+## Manual Snapshot v2 Export/Load Smoke
+
+1. Launch `BDInfo.exe` with no arguments.
+2. Confirm the main window opens normally.
+3. Select a decrypted Blu-ray root, for example `V:\`.
+4. Scan a known playlist.
+5. Open the report view.
+6. Click **Export Report...**.
+7. Confirm the default export filter is text `.txt`.
+8. Export the text report and confirm the file extension is `.txt`.
+9. Export **BDInfo Snapshot v2** and confirm the file extension is `.bdinfo`.
+10. Export legacy JSON and confirm the file extension is `.json.bdinfo`.
+11. Export legacy XML and confirm the file extension is `.xml.bdinfo`.
+12. Close BDInfo.
+13. Reopen BDInfo with the exported Snapshot v2 `.bdinfo`.
+14. Confirm the loaded report shows playlists and streams.
+15. Open the report view and confirm the text report can be regenerated.
+16. Open chart views and confirm charts render without the original disc.
+
+## PR Notes
+
+Record:
+
+- BDInfo build commit.
+- Disc volume label.
+- Playlist ID.
+- Exported file names.
+- Whether text, Snapshot v2, legacy JSON, legacy XML, report reload, and charts passed.
+- Any visual or usability issues observed.

--- a/scripts/smoke-gui-launch.ps1
+++ b/scripts/smoke-gui-launch.ps1
@@ -1,0 +1,75 @@
+param(
+    [string] $BuildOutputPath = (Join-Path $PSScriptRoot '..\BDInfo\bin\Release'),
+    [string] $ReportPath = (Join-Path $PSScriptRoot '..\tests\fixtures\report-roundtrip\sample-snapshot-v2.bdinfo'),
+    [int] $StartupTimeoutSeconds = 15,
+    [int] $ObservationSeconds = 5
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath([string] $Path) {
+    $executionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+}
+
+function Wait-ForMainWindow([System.Diagnostics.Process] $Process, [int] $TimeoutSeconds) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($Process.HasExited) {
+            throw "BDInfo GUI exited early with code $($Process.ExitCode)."
+        }
+
+        $Process.Refresh()
+        if ($Process.MainWindowHandle -ne [IntPtr]::Zero) {
+            return
+        }
+
+        Start-Sleep -Milliseconds 250
+    }
+
+    throw "BDInfo GUI did not create a main window within $TimeoutSeconds seconds."
+}
+
+function Stop-GuiProcess([System.Diagnostics.Process] $Process) {
+    if ($null -eq $Process -or $Process.HasExited) {
+        return
+    }
+
+    [void] $Process.CloseMainWindow()
+    if (-not $Process.WaitForExit(5000)) {
+        $Process.Kill()
+        $Process.WaitForExit()
+    }
+}
+
+function Invoke-GuiLaunchSmoke([string] $ExePath, [string[]] $Arguments, [string] $Description) {
+    Write-Host "Starting GUI smoke: $Description"
+    $process = Start-Process -FilePath $ExePath -ArgumentList $Arguments -PassThru
+    try {
+        Wait-ForMainWindow $process $StartupTimeoutSeconds
+        Start-Sleep -Seconds $ObservationSeconds
+
+        if ($process.HasExited) {
+            throw "BDInfo GUI exited during observation for $Description with code $($process.ExitCode)."
+        }
+    }
+    finally {
+        Stop-GuiProcess $process
+    }
+}
+
+$buildOutputFullPath = Resolve-FullPath $BuildOutputPath
+$reportFullPath = Resolve-FullPath $ReportPath
+$exePath = Join-Path $buildOutputFullPath 'BDInfo.exe'
+
+if (-not (Test-Path -LiteralPath $exePath -PathType Leaf)) {
+    throw "BDInfo.exe was not found at $exePath. Build Release first or pass -BuildOutputPath."
+}
+
+if (-not (Test-Path -LiteralPath $reportFullPath -PathType Leaf)) {
+    throw "Snapshot report fixture was not found at $reportFullPath."
+}
+
+Invoke-GuiLaunchSmoke $exePath @() 'no arguments'
+Invoke-GuiLaunchSmoke $exePath @($reportFullPath) 'single Snapshot v2 .bdinfo path'
+
+Write-Host 'BDInfo GUI launch smoke passed.'


### PR DESCRIPTION
## Summary

- Add `scripts/smoke-gui-launch.ps1` to verify GUI startup with no arguments and with a committed Snapshot v2 `.bdinfo` fixture.
- Add `docs/MANUAL_GUI_SMOKE.md` for the remaining visual Snapshot v2 export/load/chart checks.
- Update `AGENTS.md` required verification notes for GUI launch/export work.
- Mark roadmap item 22 as in progress with the automated launch smoke and manual checklist progress recorded.

## Verification

- [x] `git diff --check`
- [x] Visual Studio MSBuild Release build
- [x] `BDInfo.exe --help`
- [ ] Real-disc CLI smoke, if this touches CLI/report/chart behavior
- [x] Exported `.bdinfo` round-trip checked, if this touches report serialization

Commands run:

```powershell
git diff --check
[scriptblock]::Create((Get-Content -LiteralPath '.\scripts\smoke-gui-launch.ps1' -Raw)) | Out-Null
& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' BDInfo.sln /p:Configuration=Release /p:Platform='Any CPU' /m
& .\scripts\smoke-gui-launch.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\BDInfo\bin\Release\BDInfo.exe --help
& .\scripts\smoke-report-roundtrip.ps1 -BuildOutputPath .\BDInfo\bin\Release
& .\scripts\smoke-hdr10plus-carryover.ps1 -BuildOutputPath .\BDInfo\bin\Release
```

Real-disc CLI smoke was not rerun because this PR adds GUI launch/checklist tooling and does not change CLI/report serialization behavior.

## Risk Notes

- GUI impact: adds noninteractive launch smoke and manual checklist only; no app behavior changes.
- CLI impact: none.
- Report format/backward compatibility impact: none.

## Release Notes

- No user-facing release note needed; verification tooling and documentation only.